### PR TITLE
Deploy base rgw external lb when no ingress can be deployed

### DIFF
--- a/pkg/controller/deployment/utils.go
+++ b/pkg/controller/deployment/utils.go
@@ -50,20 +50,6 @@ func isKubeCrush(key string) bool {
 	return key == "region" || key == "zone"
 }
 
-func isSpecIngressProxyRequired(cephSpec cephlcmv1alpha1.CephDeploymentSpec) bool {
-	// do not create ingress if no custom class name specified
-	// with default class (openstack-nginx-proxy), but without OpenStack we don't need an Ingress proxy
-	if cephSpec.IngressConfig != nil {
-		if cephSpec.IngressConfig.ControllerClassName != "" {
-			return true
-		}
-	}
-	if lcmcommon.IsOpenStackPoolsPresent(cephSpec.Pools) {
-		return true
-	}
-	return false
-}
-
 func isTypeReadyToUpdate(condition cephv1.ConditionType) bool {
 	notReadyTypes := []cephv1.ConditionType{
 		cephv1.ConditionConnecting,


### PR DESCRIPTION
Also add ability to skip external svc deploy and health check at all.

Signed-off-by: Denis Egorenko degorenko@mirantis.com