### PR TITLE
Check cephdeployment propagated nodes spec changes before task processing

### DIFF
--- a/charts/pelagia-ceph/templates/lcm/rbac/lcm-controller-rbacs.yaml
+++ b/charts/pelagia-ceph/templates/lcm/rbac/lcm-controller-rbacs.yaml
@@ -54,7 +54,7 @@ rules:
     verbs: [get, list, watch]
   # control main lcm crds
   - apiGroups: [lcm.mirantis.com]
-    resources: [cephdeploymenthealths, cephdeploymenthealths/status, cephosdremovetasks, cephosdremovetasks/status, cephdeploymentmaintenances, cephdeploymentmaintenances/status]
+    resources: [cephdeployments, cephdeployments/status, cephdeploymenthealths, cephdeploymenthealths/status, cephosdremovetasks, cephosdremovetasks/status, cephdeploymentmaintenances, cephdeploymentmaintenances/status]
     verbs: [list, get, watch, update, delete]
   # control batch cleanup jobs
   - apiGroups: [batch]

--- a/pkg/controller/osdremove-task/processer.go
+++ b/pkg/controller/osdremove-task/processer.go
@@ -58,6 +58,13 @@ func (c *cephOsdRemoveConfig) handleTask() *lcmv1alpha1.CephOsdRemoveTaskStatus 
 		c.log.Info().Msg("ready to validation")
 		return c.taskConfig.moveTaskPhase(lcmv1alpha1.TaskPhaseValidating, "validation", nil)
 	case lcmv1alpha1.TaskPhaseValidating:
+		if c.taskConfig.cephDeploymentPhase != nil {
+			if *c.taskConfig.cephDeploymentPhase != lcmv1alpha1.PhaseOnHold {
+				c.log.Info().Msgf("found related CephDeployment, which is not ready yet for task processing, current phase '%v' (expected '%v')",
+					*c.taskConfig.cephDeploymentPhase, lcmv1alpha1.PhaseOnHold)
+				break
+			}
+		}
 		if *c.taskConfig.cephHealthOsdAnalysis.CephClusterSpecGeneration != c.taskConfig.cephCluster.Generation {
 			c.log.Info().Msgf("related CephDeploymentHealth has not validated yet latest CephCluster spec (validated: %d, current: %d)",
 				*c.taskConfig.cephHealthOsdAnalysis.CephClusterSpecGeneration, c.taskConfig.cephCluster.Generation)

--- a/pkg/controller/osdremove-task/task_types.go
+++ b/pkg/controller/osdremove-task/task_types.go
@@ -45,5 +45,6 @@ type taskConfig struct {
 	task                  *lcmv1alpha1.CephOsdRemoveTask
 	cephCluster           *cephv1.CephCluster
 	cephHealthOsdAnalysis *lcmv1alpha1.OsdSpecAnalysisState
+	cephDeploymentPhase   *lcmv1alpha1.CephDeploymentPhase
 	requeueNow            bool
 }


### PR DESCRIPTION
Check cephdeployment propagated nodes spec changes before task processing

If cephdeployment present, check its changes propogated to cephcluster object before validation newly created cephosdremovetask.

Signed-off-by: Denis Egorenko degorenko@mirantis.com