### PR TITLE
Fix lcm behaviour when osd created on top of another partition

### DIFF
--- a/charts/pelagia-ceph/templates/crds/lcm.mirantis.com_cephosdremovetasks.yaml
+++ b/charts/pelagia-ceph/templates/crds/lcm.mirantis.com_cephosdremovetasks.yaml
@@ -337,6 +337,12 @@ spec:
                                       description: ID is a device id
                                       nullable: true
                                       type: string
+                                    devicePartedBy:
+                                      description: |-
+                                        PartedBy is used to highlight, that osd is placed
+                                        not on a device directly but on some partition
+                                      nullable: true
+                                      type: string
                                     devicePath:
                                       description: Path is a full device path by-path
                                         to remove

--- a/pkg/apis/ceph.pelagia.lcm/v1alpha1/task_types.go
+++ b/pkg/apis/ceph.pelagia.lcm/v1alpha1/task_types.go
@@ -221,6 +221,10 @@ type DeviceInfo struct {
 	// Partition used for removing osd on device
 	// +nullable
 	Partition string `json:"osdPartition,omitempty"`
+	// PartedBy is used to highlight, that osd is placed
+	// not on a device directly but on some partition
+	// +nullable
+	PartedBy string `json:"devicePartedBy,omitempty"`
 	// Type is a osd partition type, e.g. db or block
 	// +nullable
 	Type string `json:"osdPartitionType,omitempty"`

--- a/pkg/common/disk_daemon_types.go
+++ b/pkg/common/disk_daemon_types.go
@@ -84,6 +84,7 @@ type OsdDevice struct {
 	DeviceSymlinks   []string `json:"device_pathes,omitempty"`
 	Rotational       bool     `json:"rotational,omitempty"`
 	RelatedPartition string   `json:"partition,omitempty"`
+	PartedBy         string   `json:"parted_by,omitempty"`
 }
 
 type OsdPartition struct {

--- a/pkg/controller/health/spec_osd_verification_test.go
+++ b/pkg/controller/health/spec_osd_verification_test.go
@@ -1053,6 +1053,7 @@ func TestRunSpecAnalyse(t *testing.T) {
 				"device '/dev/vdd' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*' is specified as block device, but contains db partition '/dev/ceph-metadata/part-1'",
 				"device '/dev/vdd' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*' is specified as block device, but contains db partition '/dev/ceph-metadata/part-2'",
 				"device '/dev/vdd' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*' should have 1 osd(s), but actually found 0",
+				"device '/dev/vdd1' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*' should have 1 osd(s), but actually found 0",
 				"metadata device '/dev/vdd' is not found for osd '20' for device '/dev/vdd' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*'",
 				"metadata device '/dev/vdd' is not found for osd '25' for device '/dev/vdd' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*'",
 				"metadata device '/dev/vdd' is not found for osd '30' for device '/dev/vdb' filtered by '^/dev/disk/by-path/pci-0000:00:0[a-f].*'",

--- a/pkg/disk-daemon/daemon_test.go
+++ b/pkg/disk-daemon/daemon_test.go
@@ -46,7 +46,7 @@ func TestPrepareReport(t *testing.T) {
 			udevadmOutput:    lcmdiskdaemoninput.UdevadmReportFromNode1,
 			cephVolumeOutput: lcmdiskdaemoninput.CephVolumeLvmReportFromNode1,
 			lvmLvsOutput:     lcmdiskdaemoninput.LvmLvsReportFromNode1,
-			expectedReport:   unitinputs.DiskDaemonReportOkNode1,
+			expectedReport:   unitinputs.DiskDaemonReportOkNode1WithParted,
 		},
 		{
 			name:        "daemon report failed to prepare disk report",
@@ -64,7 +64,7 @@ func TestPrepareReport(t *testing.T) {
 			udevadmOutput:    lcmdiskdaemoninput.UdevadmReportFromNode1,
 			cephVolumeOutput: lcmdiskdaemoninput.CephVolumeLvmReportFromNode1,
 			lvmLvsOutput:     lcmdiskdaemoninput.LvmLvsReportFromNode1,
-			expectedReport:   unitinputs.DiskDaemonReportOkNode1,
+			expectedReport:   unitinputs.DiskDaemonReportOkNode1WithParted,
 		},
 		{
 			name:          "daemon report failed for osd report",

--- a/pkg/disk-daemon/disk_reporter.go
+++ b/pkg/disk-daemon/disk_reporter.go
@@ -85,7 +85,9 @@ func (d *diskDaemon) diskToOsdMap() map[string][]string {
 		for _, volume := range volumes {
 			var devs []string
 			if len(volume.Devices) > 0 {
-				devs = volume.Devices
+				for _, volDevice := range volume.Devices {
+					devs = append(devs, findDisks(d.data.runtime.disksReport.Aliases[volDevice], d.data.runtime.disksReport.BlockInfo)...)
+				}
 			} else {
 				devs = findDisks(d.data.runtime.disksReport.Aliases[volume.Path], d.data.runtime.disksReport.BlockInfo)
 			}

--- a/pkg/disk-daemon/disk_reporter_test.go
+++ b/pkg/disk-daemon/disk_reporter_test.go
@@ -224,7 +224,7 @@ var cephVolumeNode1 = map[string][]OsdVolumeInfo{
 			},
 		},
 		{
-			Devices: []string{"/dev/vdd"},
+			Devices: []string{"/dev/vdd1"},
 			LvPath:  "/dev/ceph-metadata/part-1",
 			Path:    "/dev/ceph-metadata/part-1",
 			Tags: OsdVolumeTags{
@@ -250,7 +250,7 @@ var cephVolumeNode1 = map[string][]OsdVolumeInfo{
 			Type: "block",
 		},
 		{
-			Devices: []string{"/dev/vdd"},
+			Devices: []string{"/dev/vdd1"},
 			LvPath:  "/dev/ceph-metadata/part-2",
 			Path:    "/dev/ceph-metadata/part-2",
 			Tags: OsdVolumeTags{

--- a/pkg/disk-daemon/osds_reporter_test.go
+++ b/pkg/disk-daemon/osds_reporter_test.go
@@ -185,7 +185,7 @@ func TestPrepareOsdReport(t *testing.T) {
 			name:               "regular osd report",
 			disksReport:        lcmdiskdaemoninput.DiskInfoReportCephVolumeFromNode1,
 			volumesReport:      cephVolumeNode1,
-			expectedOsdsReport: unitinputs.DiskDaemonReportOkNode1.OsdsReport,
+			expectedOsdsReport: unitinputs.DiskDaemonReportOkNode1WithParted.OsdsReport,
 			expectedIssues:     []string{},
 		},
 		{

--- a/test/unit/inputs/cephdiskdaemon.go
+++ b/test/unit/inputs/cephdiskdaemon.go
@@ -42,6 +42,19 @@ var DiskDaemonReportOkNode1 = lcmcommon.DiskDaemonReport{
 	},
 }
 
+var DiskDaemonReportOkNode1WithParted = lcmcommon.DiskDaemonReport{
+	State:       lcmcommon.DiskDaemonStateOk,
+	DisksReport: lcmdiskdaemoninput.DiskInfoReportCephVolumeFromNode1,
+	OsdsReport: &lcmcommon.DiskDaemonOsdsReport{
+		Warnings: []string{
+			"found osd db partition '/dev/ceph-metadata/part-1' for osd '20' placed on top of partition '/dev/vdd1'",
+			"found osd db partition '/dev/ceph-metadata/part-2' for osd '25' placed on top of partition '/dev/vdd1'",
+			"found physical osd db partition '/dev/vda14' for osd '30'",
+		},
+		Osds: lcmdiskdaemoninput.OsdDevicesInfoNode1WithParted,
+	},
+}
+
 var DiskDaemonReportOkNode1SomeDevLost = lcmcommon.DiskDaemonReport{
 	State:       lcmcommon.DiskDaemonStateOk,
 	DisksReport: lcmdiskdaemoninput.DiskInfoReportCephVolumeSomeOsdLostFromNode1,

--- a/test/unit/inputs/disk-daemon/node1_outputs.go
+++ b/test/unit/inputs/disk-daemon/node1_outputs.go
@@ -51,8 +51,12 @@ var LsblkReportFromNode1 = `{
       {"name": "/dev/vdc", "kname": "/dev/vdc", "maj:min": "8:32", "rota": true, "type": "disk", "pkname": null, "serial": null},
       {"name": "/dev/vdd", "kname": "/dev/vdd", "maj:min": "8:48", "rota": true, "type": "disk", "pkname": null, "serial": "e8d89e2f-ffc6-4988-9",
          "children": [
-            {"name": "/dev/mapper/ceph--metadata-part--1", "kname": "/dev/dm-2", "maj:min": "253:2", "rota": true, "type": "lvm", "pkname": "/dev/vdd", "fstype": "ceph_bluestore", "serial": null},
-            {"name": "/dev/mapper/ceph--metadata-part--2", "kname": "/dev/dm-3", "maj:min": "253:3", "rota": true, "type": "lvm", "pkname": "/dev/vdd", "fstype": "ceph_bluestore", "serial": null}
+            {"name": "/dev/vdd1", "kname": "/dev/vdd1", "maj:min": "8:49", "rota": true, "type": "part", "pkname": "/dev/vdd", "serial": null,
+         	   "children": [
+	               {"name": "/dev/mapper/ceph--metadata-part--1", "kname": "/dev/dm-2", "maj:min": "253:2", "rota": true, "type": "lvm", "pkname": "/dev/vdd1", "fstype": "ceph_bluestore", "serial": null},
+	               {"name": "/dev/mapper/ceph--metadata-part--2", "kname": "/dev/dm-3", "maj:min": "253:3", "rota": true, "type": "lvm", "pkname": "/dev/vdd1", "fstype": "ceph_bluestore", "serial": null}
+	            ]
+	         }
          ]
       },
       {"name": "/dev/vde", "kname": "/dev/vde", "maj:min": "8:112", "rota": true, "type": "disk", "pkname": null, "serial": "2926ff77-7491-4447-a",
@@ -97,7 +101,8 @@ var UdevadmReportFromNode1 = map[string]string{
 	"/dev/vda15": "/dev/disk/by-path/pci-0000:00:09.0-part15 /dev/disk/by-label/UEFI /dev/disk/by-uuid/A82C-5E66 /dev/disk/by-path/virtio-pci-0000:00:09.0-part15 /dev/disk/by-partuuid/ef825b91-d4cc-47b3-bf54-99c78546a9c4",
 	"/dev/vdb":   "/dev/disk/by-id/lvm-pv-uuid-yd92Oj-9hBf-2w2n-IEjf-nBJ1-2dMk-kBeMZI /dev/disk/by-path/pci-0000:00:0a.0 /dev/disk/by-path/virtio-pci-0000:00:0a.0 /dev/disk/by-id/virtio-996ea59f-7f47-4fac-b",
 	"/dev/vdc":   "/dev/disk/by-uuid/BA42-906E /dev/disk/by-path/pci-0000:00:0b.0 /dev/disk/by-path/virtio-pci-0000:00:0b.0 /dev/disk/by-label/config-2",
-	"/dev/vdd":   "/dev/disk/by-path/virtio-pci-0000:00:0e.0 /dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9 /dev/disk/by-path/pci-0000:00:0e.0 /dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
+	"/dev/vdd":   "/dev/disk/by-path/virtio-pci-0000:00:0e.0 /dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9 /dev/disk/by-path/pci-0000:00:0e.0",
+	"/dev/vdd1":  "/dev/disk/by-path/virtio-pci-0000:00:0e.0-part1 /dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9-part1 /dev/disk/by-path/pci-0000:00:0e.0-part1 /dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
 	"/dev/vde":   "/dev/disk/by-id/lvm-pv-uuid-nzJOk1-kLTM-ErxQ-0N4c-DpDU-0zhE-Q9hRJP /dev/disk/by-id/virtio-2926ff77-7491-4447-a /dev/disk/by-path/pci-0000:00:0f.0 /dev/disk/by-path/virtio-pci-0000:00:0f.0",
 	"/dev/vdf":   "/dev/disk/by-path/pci-0000:00:10.0 /dev/disk/by-id/lvm-pv-uuid-fZ7Efo-X0nc-lAR3-lzik-MjMT-0rml-lZNf7b /dev/disk/by-path/virtio-pci-0000:00:10.0 /dev/disk/by-id/virtio-b7ea1c8c-89b8-4354-8",
 	"/dev/vdh":   "/dev/disk/by-path/pci-0000:00:11.0 /dev/disk/by-id/lvm-pv-uuid-gN4hiQ-gqT4-V19I-kvfA-fHWf-YIsh-gPFLTB /dev/disk/by-id/virtio-cf77cbec-ca01-45d9-a /dev/disk/by-path/virtio-pci-0000:00:11.0",
@@ -131,7 +136,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 			Childrens: []string{},
 		},
 		"/dev/mapper/ceph--metadata-part--1": {
-			Kname: "/dev/dm-2", Type: "lvm", Rotational: true, MajMin: "253:2", Parent: []string{"/dev/vdd"},
+			Kname: "/dev/dm-2", Type: "lvm", Rotational: true, MajMin: "253:2", Parent: []string{"/dev/vdd1"},
 			Symlinks: []string{
 				"/dev/disk/by-id/dm-name-ceph--metadata-part--1",
 				"/dev/disk/by-id/dm-uuid-LVM-4NjWWqNazXbV26cmzMqOasZgbTwEPpZaUW1YZSAnvx7CLqXUAIZ5UKlcZx8w8lWo",
@@ -139,7 +144,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 			Childrens: []string{},
 		},
 		"/dev/mapper/ceph--metadata-part--2": {
-			Kname: "/dev/dm-3", Type: "lvm", Rotational: true, MajMin: "253:3", Parent: []string{"/dev/vdd"},
+			Kname: "/dev/dm-3", Type: "lvm", Rotational: true, MajMin: "253:3", Parent: []string{"/dev/vdd1"},
 			Symlinks: []string{
 				"/dev/disk/by-id/dm-name-ceph--metadata-part--2",
 				"/dev/disk/by-id/dm-uuid-LVM-4NjWWqNazXbV26cmzMqOasZgbTwEPpZaH1waxWke4fbXEDXucEbZNeB4ZDfBeUrW",
@@ -228,10 +233,19 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/vdd": {
 			Kname: "/dev/vdd", Type: "disk", Rotational: true, MajMin: "8:48", Parent: []string{""}, Serial: "e8d89e2f-ffc6-4988-9",
 			Symlinks: []string{
-				"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
 				"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9",
 				"/dev/disk/by-path/pci-0000:00:0e.0",
 				"/dev/disk/by-path/virtio-pci-0000:00:0e.0",
+			},
+			Childrens: []string{"/dev/vdd1"},
+		},
+		"/dev/vdd1": {
+			Kname: "/dev/vdd1", Type: "part", Rotational: true, MajMin: "8:49", Parent: []string{"/dev/vdd"}, Serial: "",
+			Symlinks: []string{
+				"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
+				"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9-part1",
+				"/dev/disk/by-path/pci-0000:00:0e.0-part1",
+				"/dev/disk/by-path/virtio-pci-0000:00:0e.0-part1",
 			},
 			Childrens: []string{"/dev/mapper/ceph--metadata-part--1", "/dev/mapper/ceph--metadata-part--2"},
 		},
@@ -299,7 +313,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/disk/by-id/dm-uuid-LVM-VjASpFzahZwHYS2XN4EblEfLAfVwAImtnWhRvxcC38bhRLCw9S8sCCR7JvTuSbco": "/dev/mapper/ceph--992bbd78--3d8e--4cc3--93dc--eae387309364-osd--block--f4edb5cd--fb1e--4620--9419--3f9a4fcecba5",
 		"/dev/disk/by-id/dm-uuid-LVM-hVhQGAaFSKQ12ENRZABVk0nXCAos3JGulscWc97Kr4AQJNmIG0CbWYNy7fSDiVCe": "/dev/mapper/vg_root-lv_root",
 		"/dev/disk/by-id/dm-uuid-LVM-oPXPcruZ1AK9dkZOsPR9ZW7PzVb9xtFrOnhN24VqDzKIOPBZLd60UQpS6PpCEzQs": "/dev/mapper/ceph--21312wds--sdfv--vs3f--scv3--sdfdsg23edaa-osd--block--vbsgs3a3--sdcv--casq--sd11--asd12dasczsf",
-		"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU":                           "/dev/vdd",
+		"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU":                           "/dev/vdd1",
 		"/dev/disk/by-id/lvm-pv-uuid-K7zgwt-1AY8-QxFu-ltxQ-lCnI-XMe0-91XwfL":                           "/dev/md127",
 		"/dev/disk/by-id/lvm-pv-uuid-fZ7Efo-X0nc-lAR3-lzik-MjMT-0rml-lZNf7b":                           "/dev/vdf",
 		"/dev/disk/by-id/lvm-pv-uuid-gN4hiQ-gqT4-V19I-kvfA-fHWf-YIsh-gPFLTB":                           "/dev/vdh",
@@ -313,6 +327,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/disk/by-id/virtio-b7ea1c8c-89b8-4354-8":                                                  "/dev/vdf",
 		"/dev/disk/by-id/virtio-cf77cbec-ca01-45d9-a":                                                  "/dev/vdh",
 		"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9":                                                  "/dev/vdd",
+		"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9-part1":                                            "/dev/vdd1",
 		// disk path by label
 		"/dev/disk/by-label/UEFI":            "/dev/vda15",
 		"/dev/disk/by-label/cloudimg-rootfs": "/dev/vda1",
@@ -330,6 +345,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/disk/by-path/pci-0000:00:0a.0":               "/dev/vdb",
 		"/dev/disk/by-path/pci-0000:00:0b.0":               "/dev/vdc",
 		"/dev/disk/by-path/pci-0000:00:0e.0":               "/dev/vdd",
+		"/dev/disk/by-path/pci-0000:00:0e.0-part1":         "/dev/vdd1",
 		"/dev/disk/by-path/pci-0000:00:0f.0":               "/dev/vde",
 		"/dev/disk/by-path/pci-0000:00:10.0":               "/dev/vdf",
 		"/dev/disk/by-path/pci-0000:00:11.0":               "/dev/vdh",
@@ -341,6 +357,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/disk/by-path/virtio-pci-0000:00:0a.0":        "/dev/vdb",
 		"/dev/disk/by-path/virtio-pci-0000:00:0b.0":        "/dev/vdc",
 		"/dev/disk/by-path/virtio-pci-0000:00:0e.0":        "/dev/vdd",
+		"/dev/disk/by-path/virtio-pci-0000:00:0e.0-part1":  "/dev/vdd1",
 		"/dev/disk/by-path/virtio-pci-0000:00:0f.0":        "/dev/vde",
 		"/dev/disk/by-path/virtio-pci-0000:00:10.0":        "/dev/vdf",
 		"/dev/disk/by-path/virtio-pci-0000:00:11.0":        "/dev/vdh",
@@ -375,6 +392,7 @@ var DiskInfoReportLsblkFromNode1 = &lcmcommon.DiskDaemonDisksReport{
 		"/dev/vdb":   "/dev/vdb",
 		"/dev/vdc":   "/dev/vdc",
 		"/dev/vdd":   "/dev/vdd",
+		"/dev/vdd1":  "/dev/vdd1",
 		"/dev/vde":   "/dev/vde",
 		"/dev/vdf":   "/dev/vdf",
 		"/dev/vdh":   "/dev/vdh",
@@ -671,7 +689,7 @@ var CephVolumeLvmReportFromNode1 = `{
         },
         {
             "devices": [
-                "/dev/vdd"
+                "/dev/vdd1"
             ],
             "lv_name": "part-1",
             "lv_path": "/dev/ceph-metadata/part-1",
@@ -733,7 +751,7 @@ var CephVolumeLvmReportFromNode1 = `{
         },
         {
             "devices": [
-                "/dev/vdd"
+                "/dev/vdd1"
             ],
             "lv_name": "part-2",
             "lv_path": "/dev/ceph-metadata/part-2",
@@ -821,8 +839,8 @@ var LvmLvsReportFromNode1 = `{
 var FoundLvmsFromNode1 = map[string][]string{
 	"/dev/mapper/vg_root-lv_root": {"/dev/md127"},
 	"/dev/mapper/ceph--992bbd78--3d8e--4cc3--93dc--eae387309364-osd--block--f4edb5cd--fb1e--4620--9419--3f9a4fcecba5": {"/dev/vdb"},
-	"/dev/mapper/ceph--metadata-part--1": {"/dev/vdd"},
-	"/dev/mapper/ceph--metadata-part--2": {"/dev/vdd"},
+	"/dev/mapper/ceph--metadata-part--1": {"/dev/vdd1"},
+	"/dev/mapper/ceph--metadata-part--2": {"/dev/vdd1"},
 	"/dev/mapper/ceph--21312wds--sdfv--vs3f--scv3--sdfdsg23edaa-osd--block--vbsgs3a3--sdcv--casq--sd11--asd12dasczsf": {"/dev/vde"},
 	"/dev/mapper/ceph--2efce189--afb7--452f--bd32--c73b5017a0da-osd--block--d49fd9bf--d2dd--4c3d--824d--87f3f17ea44a": {"/dev/vdf"},
 }

--- a/test/unit/inputs/disk-daemon/osds_info.go
+++ b/test/unit/inputs/disk-daemon/osds_info.go
@@ -43,7 +43,6 @@ var OsdDevicesInfoNode1 = map[string][]lcmcommon.OsdDaemonInfo{
 					DeviceID:   "e8d89e2f-ffc6-4988-9",
 					Rotational: true,
 					DeviceSymlinks: []string{
-						"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
 						"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9",
 						"/dev/disk/by-path/pci-0000:00:0e.0",
 						"/dev/disk/by-path/virtio-pci-0000:00:0e.0",
@@ -101,7 +100,6 @@ var OsdDevicesInfoNode1 = map[string][]lcmcommon.OsdDaemonInfo{
 					DeviceID:   "e8d89e2f-ffc6-4988-9",
 					Rotational: true,
 					DeviceSymlinks: []string{
-						"/dev/disk/by-id/lvm-pv-uuid-7nUuVo-Zpzv-Tqze-5rtG-Y8f0-HdvQ-m6WXIU",
 						"/dev/disk/by-id/virtio-e8d89e2f-ffc6-4988-9",
 						"/dev/disk/by-path/pci-0000:00:0e.0",
 						"/dev/disk/by-path/virtio-pci-0000:00:0e.0",
@@ -194,6 +192,19 @@ var OsdDevicesInfoNode1 = map[string][]lcmcommon.OsdDaemonInfo{
 		},
 	},
 }
+
+var OsdDevicesInfoNode1WithParted = func() map[string][]lcmcommon.OsdDaemonInfo {
+	newMap := map[string][]lcmcommon.OsdDaemonInfo{}
+	for osd, info := range OsdDevicesInfoNode1 {
+		newMap[osd] = append([]lcmcommon.OsdDaemonInfo{}, info...)
+		if osd == "20" || osd == "25" {
+			newDevices := append([]lcmcommon.OsdDevice{}, info[0].Devices...)
+			newDevices[1].PartedBy = "/dev/vdd1"
+			newMap[osd][0].Devices = newDevices
+		}
+	}
+	return newMap
+}()
 
 var OsdDevicesSomeLostInfoNode1 = map[string][]lcmcommon.OsdDaemonInfo{
 	"20": {


### PR DESCRIPTION
When OSD DB created not directly on a disk, but on another partition LCM works incorrectly. So avoid that problem.

(cherry picked from commit 61578debfd347b9eca3af6f978a3e14880fa6231)