### PR TITLE
Fix typo for reweight param from osd tree output

### DIFF
--- a/pkg/common/ceph_types.go
+++ b/pkg/common/ceph_types.go
@@ -47,7 +47,7 @@ type OsdTree struct {
 		DeviceClass string  `json:"device_class"`
 		Status      string  `json:"status"`
 		Weight      float64 `json:"crush_weight"`
-		Reweight    int     `json:"reweight"`
+		Reweight    float64 `json:"reweight"`
 	} `json:"nodes"`
 }
 


### PR DESCRIPTION
Avoid possible osd tree output unmarshall fail, when node has temp reweight set to non-int value.

(cherry picked from commit 71b76a9ac88da359369ed8ad345db810627c6635)

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>