### PR TITLE
Update Ceph/Rook images with multiarch support

### DIFF
--- a/charts/pelagia-ceph/values.yaml
+++ b/charts/pelagia-ceph/values.yaml
@@ -87,50 +87,50 @@ images:
     operator:
       repository: pelagia/rook
       tag:
-        latest: &latestImageRook v1.17.4-23
+        latest: &latestImageRook v1.17.4-27
         squid: *latestImageRook
         reef: *latestImageRook
   ceph:
     repository: pelagia/ceph
     tag:
-      latest: &latestImageCeph v19.2.3-6.cve
+      latest: &latestImageCeph v19.2.3-12.release
       squid: *latestImageCeph
-      reef: v18.2.7-4.cve
+      reef: v18.2.7-6.release
   csi:
     ceph:
       repository: pelagia/cephcsi
       tag:
-        latest: &latestImageCephCSI v3.14.0-6.cve
+        latest: &latestImageCephCSI v3.14.0-11.release
         squid: *latestImageCephCSI
         reef: *latestImageCephCSI
     registrar:
       repository: pelagia/cephcsi-registrar
       tag:
-        latest: &latestImageRegistar v2.13.0-4.cve
+        latest: &latestImageRegistar v2.13.0-9.release
         squid: *latestImageRegistar
         reef: *latestImageRegistar
     provisioner:
       repository: pelagia/cephcsi-provisioner
       tag:
-        latest: &latestImageProvisioner v5.2.0-4.cve
+        latest: &latestImageProvisioner v5.2.0-9.release
         squid: *latestImageProvisioner
         reef: *latestImageProvisioner
     snapshotter:
       repository: pelagia/cephcsi-snapshotter
       tag:
-        latest: &latestImageSnapshotter v8.2.0-4.cve
+        latest: &latestImageSnapshotter v8.2.0-9.release
         squid: *latestImageSnapshotter
         reef: *latestImageSnapshotter
     attacher:
       repository: pelagia/cephcsi-attacher
       tag:
-        latest: &latestImageAttacher v4.8.0-4.cve
+        latest: &latestImageAttacher v4.8.0-9.release
         squid: *latestImageAttacher
         reef: *latestImageAttacher
     resizer:
       repository: pelagia/cephcsi-resizer
       tag:
-        latest: &latestImageResizer v1.13.2-4.cve
+        latest: &latestImageResizer v1.13.2-9.release
         squid: *latestImageResizer
         reef: *latestImageResizer
 rookConfig:

--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -4,7 +4,7 @@ global:
 images:
   snapshotController:
     repository: pelagia/snapshot-controller
-    tag: v8.2.0-4.cve
+    tag: v8.2.0-9.release
     fullName: ""
 
 snapshotControllerConfig:


### PR DESCRIPTION
Set images with multiarch support in chart values.

Related-Issue: #32
Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>