### PR TITLE
Use default pool device class for some e2e tests

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -249,6 +249,10 @@ func TestValidationFailure(t *testing.T) {
 		cd.Spec.ObjectStorage.Rgw.MetadataPool.Replicated = nil
 		cd.Spec.ObjectStorage.Rgw.MetadataPool.ErasureCoded = nil
 	}
+	poolDefaultClass := f.GetDefaultPoolDeviceClass(cd)
+	if poolDefaultClass == "" {
+		t.Fatal("failed to find default pool")
+	}
 	// cephfs validation
 	cd.Spec.SharedFilesystem = &cephlcmv1alpha1.CephSharedFilesystem{
 		CephFS: []cephlcmv1alpha1.CephFS{
@@ -259,7 +263,7 @@ func TestValidationFailure(t *testing.T) {
 					{
 						Name: "fake-datapool-1",
 						CephPoolSpec: cephlcmv1alpha1.CephPoolSpec{
-							DeviceClass: "hdd",
+							DeviceClass: poolDefaultClass,
 							ErasureCoded: &cephlcmv1alpha1.CephPoolErasureCodedSpec{
 								CodingChunks: 2,
 								DataChunks:   1,
@@ -269,7 +273,7 @@ func TestValidationFailure(t *testing.T) {
 					{
 						Name: "fake-datapool-2",
 						CephPoolSpec: cephlcmv1alpha1.CephPoolSpec{
-							DeviceClass: "hdd",
+							DeviceClass: poolDefaultClass,
 						},
 					},
 				},

--- a/test/e2e/cephfs_test.go
+++ b/test/e2e/cephfs_test.go
@@ -508,6 +508,10 @@ func TestCephFSManila(t *testing.T) {
 		}
 	}
 	f.Step(t, "Enable CephFS for Manila in Ceph cluster")
+	poolDefaultClass := f.GetDefaultPoolDeviceClass(cd)
+	if poolDefaultClass == "" {
+		t.Fatal("failed to find default pool")
+	}
 	cephFSName := fmt.Sprintf("shared-cephfs-%d", time.Now().Unix())
 	cephFS := cephlcmv1alpha1.CephFS{
 		Name: cephFSName,
@@ -515,7 +519,7 @@ func TestCephFSManila(t *testing.T) {
 			{
 				Name: "data-pool",
 				CephPoolSpec: cephlcmv1alpha1.CephPoolSpec{
-					DeviceClass:   "hdd",
+					DeviceClass:   poolDefaultClass,
 					FailureDomain: "host",
 					Replicated: &cephlcmv1alpha1.CephPoolReplicatedSpec{
 						Size: 2,
@@ -524,7 +528,7 @@ func TestCephFSManila(t *testing.T) {
 			},
 		},
 		MetadataPool: cephlcmv1alpha1.CephPoolSpec{
-			DeviceClass:   "hdd",
+			DeviceClass:   poolDefaultClass,
 			FailureDomain: "host",
 			Replicated: &cephlcmv1alpha1.CephPoolReplicatedSpec{
 				Size: 2,

--- a/test/e2e/framework/helpers.go
+++ b/test/e2e/framework/helpers.go
@@ -161,3 +161,14 @@ func GetRgwPublicEndpoint(cdhName string) (string, error) {
 	}
 	return cdh.Status.HealthReport.ClusterDetails.RgwInfo.PublicEndpoint, nil
 }
+
+func GetDefaultPoolDeviceClass(cd *cephlcmv1alpha.CephDeployment) string {
+	poolDefaultClass := ""
+	for _, pool := range cd.Spec.Pools {
+		if pool.StorageClassOpts.Default {
+			poolDefaultClass = pool.DeviceClass
+			break
+		}
+	}
+	return poolDefaultClass
+}

--- a/test/e2e/rgw_multisite_test.go
+++ b/test/e2e/rgw_multisite_test.go
@@ -66,6 +66,10 @@ func TestMultisiteRgw(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	poolDefaultClass := f.GetDefaultPoolDeviceClass(cd)
+	if poolDefaultClass == "" {
+		t.Fatal("failed to find default pool")
+	}
 
 	realmName := ""
 	zonegroupName := ""
@@ -91,13 +95,13 @@ func TestMultisiteRgw(t *testing.T) {
 					{
 						Name: "rgw-storezone",
 						MetadataPool: cephlcmv1alpha1.CephPoolSpec{
-							DeviceClass: "hdd",
+							DeviceClass: poolDefaultClass,
 							Replicated: &cephlcmv1alpha1.CephPoolReplicatedSpec{
 								Size: 3,
 							},
 						},
 						DataPool: cephlcmv1alpha1.CephPoolSpec{
-							DeviceClass: "hdd",
+							DeviceClass: poolDefaultClass,
 							ErasureCoded: &cephlcmv1alpha1.CephPoolErasureCodedSpec{
 								CodingChunks: 1,
 								DataChunks:   2,
@@ -230,13 +234,13 @@ func TestMultisiteRgw(t *testing.T) {
 				{
 					Name: zoneName,
 					MetadataPool: cephlcmv1alpha1.CephPoolSpec{
-						DeviceClass: "hdd",
+						DeviceClass: poolDefaultClass,
 						Replicated: &cephlcmv1alpha1.CephPoolReplicatedSpec{
 							Size: 3,
 						},
 					},
 					DataPool: cephlcmv1alpha1.CephPoolSpec{
-						DeviceClass: "hdd",
+						DeviceClass: poolDefaultClass,
 						ErasureCoded: &cephlcmv1alpha1.CephPoolErasureCodedSpec{
 							CodingChunks: 1,
 							DataChunks:   2,


### PR DESCRIPTION
Use default pool device class for:
* volume expand test;
* cephfs+manila;
* basic;
* volume backend;
* rgw multisite;


(cherry picked from commit 6a806ada234e908de2650d68b419a2d6e99613e6)