### PR TITLE
Fix pelagia deployment RBAC for cluster remove procedure

### DIFF
--- a/charts/pelagia-ceph/templates/cephdeployment/rbac/ceph-controller-rbac.yaml
+++ b/charts/pelagia-ceph/templates/cephdeployment/rbac/ceph-controller-rbac.yaml
@@ -58,7 +58,7 @@ rules:
     verbs: [list, get, watch, patch, update]
   - apiGroups: [lcm.mirantis.com]
     resources: [cephdeploymenthealths, cephdeploymentsecrets, cephdeploymentmaintenances]
-    verbs: [list, get, create, update]
+    verbs: [list, get, create, update, delete]
   - apiGroups: [lcm.mirantis.com]
     resources: [cephosdremovetasks]
     verbs: [list, get]
@@ -87,7 +87,7 @@ rules:
   # Application: read/write creds to/from shared namespace.
   - apiGroups: [""]
     resources: [secrets]
-    verbs: [list, get, create, patch]
+    verbs: [list, get, create, patch, delete]
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -131,9 +131,8 @@ var (
 		OsdPgRebalanceTimeout: 30 * time.Minute,
 	}
 	defaultDeployParams = DeployParams{
-		LogLevel:                     zerolog.InfoLevel,
-		OpenstackCephSharedNamespace: "openstack-ceph-shared",
-		RgwPublicAccessLabel:         "external_access=rgw",
+		LogLevel:             zerolog.InfoLevel,
+		RgwPublicAccessLabel: "external_access=rgw",
 	}
 )
 

--- a/pkg/controller/deployment/controller.go
+++ b/pkg/controller/deployment/controller.go
@@ -769,14 +769,16 @@ func (c *cephDeploymentConfig) cleanCephDeployment() (bool, error) {
 		}
 		return false, err
 	})
-	// Delete openstack secret
-	if c.cdConfig.cephDpl.Spec.ExtraOpts != nil && c.cdConfig.cephDpl.Spec.ExtraOpts.DisableOsKeys {
-		c.log.Warn().Msgf("openstack secret %s/%s ensure disabled, skip deleting. Do not forget to remove it manually",
-			c.lcmConfig.DeployParams.OpenstackCephSharedNamespace, openstackSharedSecret)
-	} else {
-		runRemoveState("openstack shared secret", func() (bool, error) {
-			return c.deleteOpenstackSecret()
-		})
+	if !c.cdConfig.cephDpl.Spec.External {
+		// Delete openstack secret
+		if c.cdConfig.cephDpl.Spec.ExtraOpts != nil && c.cdConfig.cephDpl.Spec.ExtraOpts.DisableOsKeys {
+			c.log.Warn().Msgf("openstack secret %s/%s ensure disabled, skip deleting. Do not forget to remove it manually",
+				c.lcmConfig.DeployParams.OpenstackCephSharedNamespace, openstackSharedSecret)
+		} else {
+			runRemoveState("openstack shared secret", func() (bool, error) {
+				return c.deleteOpenstackSecret()
+			})
+		}
 	}
 	// Delete object storage stuff
 	runRemoveState("object storage", func() (bool, error) {

--- a/pkg/controller/deployment/controller_test.go
+++ b/pkg/controller/deployment/controller_test.go
@@ -63,6 +63,7 @@ func fakeDeploymentConfig(dconfig *deployConfig, lcmConfigData map[string]string
 		lcmConfigData = map[string]string{}
 	}
 	lcmConfigData["DEPLOYMENT_LOG_LEVEL"] = "TRACE"
+	lcmConfigData["DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE"] = "openstack-ceph-shared"
 	lcmConfig := lcmconfig.ReadConfiguration(log.With().Str(lcmcommon.LoggerObjectField, "configmap").Logger(), lcmConfigData)
 	sublog := log.With().Str(lcmcommon.LoggerObjectField, "cephdeployment").Logger().Level(lcmConfig.DeployParams.LogLevel)
 	dc := deployConfig{
@@ -1434,7 +1435,7 @@ func TestCleanCephDeployment(t *testing.T) {
 				"delete-secrets":                    errors.New("failed to delete secret"),
 				"delete-storageclasses":             errors.New("failed to delete storageclass"),
 			},
-			expectedError: "deletion is not completed for CephDeployment: failed to remove CephDeploymentSecret 'lcm-namespace/cephcluster', failed to remove CephDeploymentMaintenance 'lcm-namespace/cephcluster', failed to remove openstack shared secret, failed to remove object storage, failed to remove rbd mirror, failed to remove ceph clients, failed to remove storage classes, failed to remove external resources",
+			expectedError: "deletion is not completed for CephDeployment: failed to remove CephDeploymentSecret 'lcm-namespace/cephcluster', failed to remove CephDeploymentMaintenance 'lcm-namespace/cephcluster', failed to remove object storage, failed to remove rbd mirror, failed to remove ceph clients, failed to remove storage classes, failed to remove external resources",
 		},
 		{
 			name:           "external - delete resources is in progress (first step)",

--- a/pkg/controller/deployment/openstack_test.go
+++ b/pkg/controller/deployment/openstack_test.go
@@ -35,6 +35,7 @@ import (
 func TestDeleteOpenstackSecret(t *testing.T) {
 	tests := []struct {
 		name          string
+		nonmosk       bool
 		deleteError   error
 		deleted       bool
 		expectedError string
@@ -51,10 +52,18 @@ func TestDeleteOpenstackSecret(t *testing.T) {
 			deleteError:   errors.New("secrets delete failed"),
 			expectedError: "failed to delete openstack secret openstack-ceph-shared/openstack-ceph-keys: secrets delete failed",
 		},
+		{
+			name:    "delete openstack secrets - non-mosk, success",
+			nonmosk: true,
+			deleted: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := fakeDeploymentConfig(nil, nil)
+			if test.nonmosk {
+				c.lcmConfig.DeployParams.OpenstackCephSharedNamespace = ""
+			}
 			inputRes := map[string]runtime.Object{"secrets": &corev1.SecretList{}}
 			if !test.deleted {
 				inputRes["secrets"] = &corev1.SecretList{Items: []corev1.Secret{unitinputs.OpenstackSecretGenerated}}

--- a/test/unit/inputs/configmap.go
+++ b/test/unit/inputs/configmap.go
@@ -58,10 +58,11 @@ var PelagiaConfig = corev1.ConfigMap{
 		Name:      "pelagia-lcmconfig",
 	},
 	Data: map[string]string{
-		"DEPLOYMENT_CEPH_IMAGE":     fmt.Sprintf("mirantis.azurecr.io/ceph/ceph:%s", LatestCephVersionImage),
-		"DEPLOYMENT_ROOK_IMAGE":     "mirantis.azurecr.io/mirantis/rook:v1.17.4-15",
-		"DEPLOYMENT_NETPOL_ENABLED": "true",
-		"DEPLOYMENT_LOG_LEVEL":      "trace",
+		"DEPLOYMENT_CEPH_IMAGE":                      fmt.Sprintf("mirantis.azurecr.io/ceph/ceph:%s", LatestCephVersionImage),
+		"DEPLOYMENT_ROOK_IMAGE":                      "mirantis.azurecr.io/mirantis/rook:v1.17.4-15",
+		"DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE": "openstack-ceph-shared",
+		"DEPLOYMENT_NETPOL_ENABLED":                  "true",
+		"DEPLOYMENT_LOG_LEVEL":                       "trace",
 	},
 }
 
@@ -71,11 +72,12 @@ var PelagiaConfigForPrevCephVersion = corev1.ConfigMap{
 		Name:      "pelagia-lcmconfig",
 	},
 	Data: map[string]string{
-		"DEPLOYMENT_CEPH_RELEASE":   PreviousCephVersion,
-		"DEPLOYMENT_CEPH_IMAGE":     fmt.Sprintf("mirantis.azurecr.io/ceph/ceph:%s", PreviousCephVersionImage),
-		"DEPLOYMENT_ROOK_IMAGE":     "mirantis.azurecr.io/mirantis/rook:v1.16.7-1",
-		"DEPLOYMENT_NETPOL_ENABLED": "true",
-		"DEPLOYMENT_LOG_LEVEL":      "trace",
+		"DEPLOYMENT_CEPH_RELEASE":                    PreviousCephVersion,
+		"DEPLOYMENT_CEPH_IMAGE":                      fmt.Sprintf("mirantis.azurecr.io/ceph/ceph:%s", PreviousCephVersionImage),
+		"DEPLOYMENT_ROOK_IMAGE":                      "mirantis.azurecr.io/mirantis/rook:v1.16.7-1",
+		"DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE": "openstack-ceph-shared",
+		"DEPLOYMENT_NETPOL_ENABLED":                  "true",
+		"DEPLOYMENT_LOG_LEVEL":                       "trace",
 	},
 }
 


### PR DESCRIPTION
Add missed delete permissions for Pelagia deployment controller:
* for removing CephDeploymentSecret;
* for removing CephDeploymentMaintenance;
* for removing MOSK related secret;

Resolves: https://github.com/Mirantis/pelagia/issues/57