### PR TITLE
Continue osd remove if osd is unavailable during rebalance

### DIFF
--- a/pkg/controller/osdremove-task/executor_test.go
+++ b/pkg/controller/osdremove-task/executor_test.go
@@ -1020,6 +1020,7 @@ func TestCheckRebalance(t *testing.T) {
 	tests := []struct {
 		name           string
 		cliOutput      string
+		osdDown        bool
 		currentStatus  *lcmv1alpha1.RemoveStatus
 		expectedStatus *lcmv1alpha1.RemoveStatus
 	}{
@@ -1057,9 +1058,18 @@ func TestCheckRebalance(t *testing.T) {
 			},
 		},
 		{
-			name:          "rebalance is not finished",
+			name:          "rebalance is finished",
 			cliOutput:     `{"pg_stats":[]}`,
 			currentStatus: rebalanceStatus.DeepCopy(),
+			expectedStatus: &lcmv1alpha1.RemoveStatus{
+				Status:    lcmv1alpha1.RemoveInProgress,
+				StartedAt: rebalanceStatus.StartedAt,
+			},
+		},
+		{
+			name:          "osd became unavailable",
+			currentStatus: rebalanceStatus.DeepCopy(),
+			osdDown:       true,
 			expectedStatus: &lcmv1alpha1.RemoveStatus{
 				Status:    lcmv1alpha1.RemoveInProgress,
 				StartedAt: rebalanceStatus.StartedAt,
@@ -1077,6 +1087,9 @@ func TestCheckRebalance(t *testing.T) {
 			lcmcommon.RunPodCommand = func(_ lcmcommon.ExecConfig) (string, string, error) {
 				if test.cliOutput != "" {
 					return test.cliOutput, "", nil
+				}
+				if test.osdDown {
+					return "", "", errors.New("ceph pg ls-by-osd 5 --format json' (stdErr: Error EAGAIN: osd 5 is not up\n)")
 				}
 				return "", "", errors.New("run failed")
 			}

--- a/pkg/controller/osdremove-task/utils.go
+++ b/pkg/controller/osdremove-task/utils.go
@@ -18,6 +18,7 @@ package osdremove
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -101,6 +102,10 @@ func (c *cephOsdRemoveConfig) checkPgsForOsd(osdID string) (bool, error) {
 	cmd := fmt.Sprintf("ceph pg ls-by-osd %s --format json", osdID)
 	err := lcmcommon.RunAndParseCephToolboxCLI(c.context, c.api.Kubeclientset, c.api.Config, c.taskConfig.cephCluster.Namespace, cmd, &pgsByOsd)
 	if err != nil {
+		// if for some reasons osd became unavailable - no need to fail
+		if strings.Contains(err.Error(), fmt.Sprintf("osd %s is not up", osdID)) {
+			return false, nil
+		}
 		c.log.Error().Err(err).Msg("")
 		return false, err
 	}


### PR DESCRIPTION
In some cases osd may became unavailable during waiting rebalance completed, just continue remove procedure instead of fail.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>

(cherry picked from commit 7b7b03abdd1becb0c08e97a9da11075f5fdf52e6)