### PR TITLE
Fix rgw validation and do not fail it for ssl only case

### DIFF
--- a/pkg/controller/deployment/validate.go
+++ b/pkg/controller/deployment/validate.go
@@ -452,8 +452,8 @@ func validateObjectStorageSpec(cephDpl *cephlcmv1alpha1.CephDeployment, nodesLis
 
 		for _, rgw := range cephDpl.Spec.ObjectStorage.Rgws {
 			rgwCasted, _ := rgw.GetSpec()
-			if rgwCasted.Gateway.Port == 0 {
-				issues = append(issues, fmt.Sprintf("rgw '%s' has no port specified", rgw.Name))
+			if rgwCasted.Gateway.Port == 0 && rgwCasted.Gateway.SecurePort == 0 {
+				issues = append(issues, fmt.Sprintf("rgw '%s' has no port or securePort specified", rgw.Name))
 			}
 			if external {
 				if rgwCasted.MetadataPool.Replicated.Size != 0 || rgwCasted.MetadataPool.ErasureCoded.DataChunks != 0 || rgwCasted.MetadataPool.ErasureCoded.CodingChunks != 0 ||

--- a/pkg/controller/deployment/validate_test.go
+++ b/pkg/controller/deployment/validate_test.go
@@ -739,7 +739,7 @@ func TestValidateObjectStorageSpec(t *testing.T) {
 				"cluster is external, rgw realms can't be created",
 				"cluster is external, rgw zonegroups can't be created",
 				"cluster is external, rgw zones can't be created",
-				"rgw 'external-rgw' has no port specified",
+				"rgw 'external-rgw' has no port or securePort specified",
 				"cluster is external, rgw 'external-rgw' pools (metadata and data) specification is not allowed",
 				"external endpoints for rgw 'external-rgw' are not provided",
 			},


### PR DESCRIPTION
If we dont need base http port do not fail spec validation, when securePort provided only instead.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>