### PR TITLE
Fix rgw e2e test when specified custom ssl cert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ ifeq (,$(shell $$GOPATH/golangci-lint version 2>/dev/null))
 	@printf "\n=== <INSTALL GO-LINT> ===\n"
 	@echo Missing golangci-lint. Going to install if for $(HOSTOS).
 ifeq ("Linux","$(HOSTOS)")
-	$(shell wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/v1.62.0/install.sh | bash -s -- -b $(GOPATH))
+	$(shell wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.1/install.sh | bash -s -- -b $(GOPATH))
 endif
 ifeq ("Darwin","$(HOSTOS)")
 	brew install golangci/tap/golangci-lint

--- a/test/e2e/rgw_test.go
+++ b/test/e2e/rgw_test.go
@@ -375,6 +375,19 @@ func runRgwAccessTest(t *testing.T, endpoint, ingressIP, domain, rgwStoreName, r
 			t.Fatal(err)
 		}
 	}
+	certSecretName := fmt.Sprintf("%s-ssl-cert", rgwStoreName)
+	for _, rgw := range cd.Spec.ObjectStorage.Rgws {
+		if rgw.Name == rgwStoreName {
+			rgwSpec, _ := rgw.GetSpec()
+			if rgwSpec.Gateway.CaBundleRef != "" {
+				certSecretName = rgwSpec.Gateway.CaBundleRef
+			} else if rgwSpec.Gateway.SSLCertificateRef != "" {
+				// backward compatibility for upgraded envs from Pelagia v1
+				certSecretName = rgwSpec.Gateway.SSLCertificateRef
+			}
+			break
+		}
+	}
 
 	f.Step(t, "Get custom rgw user credentials")
 	var userCreds *corev1.Secret
@@ -426,7 +439,7 @@ aws_secret_access_key = %s`, customAccessKey, customSecretKey),
 	}()
 
 	f.Step(t, "Create awscli pod to verify public endpoint accessibility")
-	_, err = f.TF.ManagedCluster.CreateAWSCliDeployment(awscliName, "", f.TF.E2eImage, customUserCmName, fmt.Sprintf("%s-ssl-cert", rgwStoreName), ingressIP, domain)
+	_, err = f.TF.ManagedCluster.CreateAWSCliDeployment(awscliName, "", f.TF.E2eImage, customUserCmName, certSecretName, ingressIP, domain)
 	if err != nil {
 		t.Fatalf("failed to create and configure awscli for custom rgw user: %v", err)
 	}


### PR DESCRIPTION
Use cert in secret, specified in object store gateway section for public access in e2e.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>