### PR TITLE
Add Slack channel link for discussions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For installation, deployment, and administration, see our
 [Documentation](https://mirantis.github.io/pelagia/) and
 [Quick start guide](https://mirantis.github.io/pelagia/quick-start/installation/).
 Have some questions? Use our
-[GitHub Discussions](https://github.com/Mirantis/pelagia/discussions).
+[GitHub Discussions](https://github.com/Mirantis/pelagia/discussions) or join the [#pelagia channel](https://cloud-native.slack.com/archives/C09K5TEC9JN) in CNCF Slack.
 
 # Report a Bug
 


### PR DESCRIPTION
Updated the README to include the #pelagia channel in CNCF Slack for discussions.