### PR TITLE
Bump go and images with cve fixes

### DIFF
--- a/charts/pelagia-ceph/values.yaml
+++ b/charts/pelagia-ceph/values.yaml
@@ -87,50 +87,50 @@ images:
     operator:
       repository: pelagia/rook
       tag:
-        latest: &latestImageRook v1.18.8-8
+        latest: &latestImageRook v1.18.8-9
         squid: *latestImageRook
         reef: *latestImageRook
   ceph:
     repository: pelagia/ceph
     tag:
-      latest: &latestImageCeph v19.2.4-1.release
+      latest: &latestImageCeph v19.2.4-2.cve
       squid: *latestImageCeph
       reef: v18.2.7-6.release
   csi:
     ceph:
       repository: pelagia/cephcsi
       tag:
-        latest: &latestImageCephCSI v3.15.0-5.cve
+        latest: &latestImageCephCSI v3.15.0-6.cve
         squid: *latestImageCephCSI
         reef: *latestImageCephCSI
     registrar:
       repository: pelagia/cephcsi-registrar
       tag:
-        latest: &latestImageRegistar v2.13.0-15.cve
+        latest: &latestImageRegistar v2.13.0-16.cve
         squid: *latestImageRegistar
         reef: *latestImageRegistar
     provisioner:
       repository: pelagia/cephcsi-provisioner
       tag:
-        latest: &latestImageProvisioner v5.2.0-15.cve
+        latest: &latestImageProvisioner v5.2.0-16.cve
         squid: *latestImageProvisioner
         reef: *latestImageProvisioner
     snapshotter:
       repository: pelagia/cephcsi-snapshotter
       tag:
-        latest: &latestImageSnapshotter v8.2.1-3.cve
+        latest: &latestImageSnapshotter v8.2.1-4.cve
         squid: *latestImageSnapshotter
         reef: *latestImageSnapshotter
     attacher:
       repository: pelagia/cephcsi-attacher
       tag:
-        latest: &latestImageAttacher v4.8.1-3.cve
+        latest: &latestImageAttacher v4.8.1-4.cve
         squid: *latestImageAttacher
         reef: *latestImageAttacher
     resizer:
       repository: pelagia/cephcsi-resizer
       tag:
-        latest: &latestImageResizer v1.13.2-15.cve
+        latest: &latestImageResizer v1.13.2-16.cve
         squid: *latestImageResizer
         reef: *latestImageResizer
 rookConfig:

--- a/charts/snapshot-controller/values.yaml
+++ b/charts/snapshot-controller/values.yaml
@@ -4,7 +4,7 @@ global:
 images:
   snapshotController:
     repository: pelagia/snapshot-controller
-    tag: v8.2.1-3.cve
+    tag: v8.2.1-4.cve
     fullName: ""
 
 snapshotControllerConfig:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mirantis/pelagia
 
-go 1.25.10
+go 1.25.11
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
* bump go to 1.25.11;
* bump images with cve fixes;

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>