### PR TITLE
Do not try remove cephfs subvolumegroup if cephfs is not present in cluster

### DIFF
--- a/pkg/controller/deployment/controller_test.go
+++ b/pkg/controller/deployment/controller_test.go
@@ -1475,7 +1475,7 @@ func TestCleanCephDeployment(t *testing.T) {
 			c.cdConfig.currentCephVersion = lcmcommon.Reef
 
 			lcmcommon.RunPodCommandWithValidation = func(e lcmcommon.ExecConfig) (string, string, error) {
-				if strings.HasPrefix(e.Command, "ceph fs subvolumegroup -f json") {
+				if strings.HasPrefix(e.Command, "ceph fs ls -f json") {
 					return "[]", "", nil
 				}
 				return "", "", errors.New("unexpected command")

--- a/pkg/controller/deployment/shared_filesystem.go
+++ b/pkg/controller/deployment/shared_filesystem.go
@@ -19,6 +19,7 @@ package deployment
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	lcmcommon "github.com/Mirantis/pelagia/pkg/common"
 
@@ -67,7 +68,7 @@ func (c *cephDeploymentConfig) ensureCephFS() (bool, error) {
 	for _, cephFs := range cephFsList.Items {
 		dropFS[cephFs.Name] = true
 	}
-	fsErrors := make([]error, 0)
+	fsErrors := make([]string, 0)
 	changed := false
 	for _, cephDplCephFS := range c.cdConfig.cephDpl.Spec.SharedFilesystem.CephFS {
 		delete(dropFS, cephDplCephFS.Name)
@@ -76,15 +77,17 @@ func (c *cephDeploymentConfig) ensureCephFS() (bool, error) {
 		cephFs, err := c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Get(c.context, cephDplCephFS.Name, metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
-				c.log.Error().Err(err).Msg("failed to get CephFS")
-				fsErrors = append(fsErrors, errors.Wrapf(err, "failed to get CephFS %s/%s", c.lcmConfig.RookNamespace, cephDplCephFS.Name))
+				msg := fmt.Sprintf("failed to get CephFilesytem '%s/%s'", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+				c.log.Error().Err(err).Msg(msg)
+				fsErrors = append(fsErrors, msg)
 				continue
 			}
-			c.log.Info().Msgf("creating CephFS %s/%s", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+			c.log.Info().Msgf("creating CephFS '%s/%s'", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
 			_, err := c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Create(c.context, cephFsResource, metav1.CreateOptions{})
 			if err != nil {
-				c.log.Error().Err(err).Msg("failed to create CephFS")
-				fsErrors = append(fsErrors, errors.Wrapf(err, "failed to create CephFS %s/%s", c.lcmConfig.RookNamespace, cephDplCephFS.Name))
+				msg := fmt.Sprintf("failed to create CephFilesytem '%s/%s'", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+				c.log.Error().Err(err).Msg(msg)
+				fsErrors = append(fsErrors, msg)
 				continue
 			}
 			changed = true
@@ -95,76 +98,83 @@ func (c *cephDeploymentConfig) ensureCephFS() (bool, error) {
 			continue
 		}
 		if !reflect.DeepEqual(cephFsResource.Spec, cephFs.Spec) {
-			c.log.Info().Msgf("updating CephFS %s/%s", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+			c.log.Info().Msgf("updating CephFS '%s/%s'", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
 			lcmcommon.ShowObjectDiff(*c.log, cephFs.Spec, cephFsResource.Spec)
 			cephFs.Spec = cephFsResource.Spec
 			_, err := c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Update(c.context, cephFs, metav1.UpdateOptions{})
 			if err != nil {
-				c.log.Error().Err(err).Msg("failed to update CephFS")
-				fsErrors = append(fsErrors, errors.Wrapf(err, "failed to update CephFS %s/%s", c.lcmConfig.RookNamespace, cephDplCephFS.Name))
+				msg := fmt.Sprintf("failed to update CephFilesytem '%s/%s'", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+				c.log.Error().Err(err).Msg(msg)
+				fsErrors = append(fsErrors, msg)
 				continue
 			}
 			changed = true
 		}
 		subvolumegroup, err := c.cephFSSubvolumegroupCommand("ls", cephDplCephFS.Name)
 		if err != nil {
-			errMsg := errors.Wrapf(err, "failed to list CephFS %s subvolumegroup", cephDplCephFS.Name)
-			c.log.Error().Err(errMsg)
-			fsErrors = append(fsErrors, errMsg)
+			msg := fmt.Sprintf("failed to list CephFS '%s' subvolumegroups", cephDplCephFS.Name)
+			c.log.Error().Err(err).Msg(msg)
+			fsErrors = append(fsErrors, msg)
 		} else if subvolumegroup == "" {
-			c.log.Info().Msgf("creating CephFS %s/%s subvolumegroup for CSI", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
+			c.log.Info().Msgf("creating CephFS '%s/%s' subvolumegroup for CSI", c.lcmConfig.RookNamespace, cephDplCephFS.Name)
 			_, err = c.cephFSSubvolumegroupCommand("create", cephDplCephFS.Name)
 			if err != nil {
-				errMsg := errors.Wrapf(err, "failed to create CephFS %s subvolumegroup", cephDplCephFS.Name)
-				c.log.Error().Err(errMsg)
-				fsErrors = append(fsErrors, errMsg)
+				msg := fmt.Sprintf("failed to create CephFS '%s' subvolumegroup", cephDplCephFS.Name)
+				c.log.Error().Err(err).Msg(msg)
+				fsErrors = append(fsErrors, msg)
 				continue
 			}
 			changed = true
 		}
 	}
 	for fsName := range dropFS {
-		subvolumegroup, err := c.cephFSSubvolumegroupCommand("ls", fsName)
+		err = c.removeCephFilesystem(fsName)
 		if err != nil {
-			errMsg := errors.Wrapf(err, "failed to list CephFS %s subvolumegroup", fsName)
-			c.log.Error().Err(errMsg)
-			fsErrors = append(fsErrors, errMsg)
-			continue
-		} else if subvolumegroup != "" {
-			c.log.Info().Msgf("removing CephFS %s/%s subvolumegroup for CSI", c.lcmConfig.RookNamespace, fsName)
-			_, err = c.cephFSSubvolumegroupCommand("rm", fsName)
-			if err != nil {
-				errMsg := errors.Wrapf(err, "failed to remove CephFS %s subvolumegroup", fsName)
-				c.log.Error().Err(errMsg)
-				fsErrors = append(fsErrors, errMsg)
-				continue
-			}
-		}
-		c.log.Info().Msgf("removing CephFS %s/%s", c.lcmConfig.RookNamespace, fsName)
-		err = c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Delete(c.context, fsName, metav1.DeleteOptions{})
-		if err != nil {
-			c.log.Error().Err(err).Msg("failed to remove CephFS")
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			fsErrors = append(fsErrors, errors.Wrapf(err, "failed to delete CephFS %s/%s", c.lcmConfig.RookNamespace, fsName))
+			msg := fmt.Sprintf("failed to remove CephFilesytem '%s'", fsName)
+			c.log.Error().Err(err).Msg(msg)
+			fsErrors = append(fsErrors, msg)
 		}
 		changed = true
 	}
 	if len(fsErrors) > 0 {
-		if len(fsErrors) > 1 {
-			msg := "multiple errors during cephFS ensure"
-			return false, errors.New(msg)
-		}
-		return false, fsErrors[0]
+		return false, errors.Errorf("error(s) during CephFilesytem(s) ensure: %s", strings.Join(fsErrors, ", "))
 	}
 	return changed, nil
+}
+
+func (c *cephDeploymentConfig) removeCephFilesystem(cephfs string) error {
+	// check first cephFS itself is present in Ceph cluster, because it may be created
+	// with wrong params/failed to create - and no subvolume for it
+	cephFsPresent, err := c.cephFsPresent(cephfs)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check CephFilesytem '%s' presence in cluster", cephfs)
+	}
+	if cephFsPresent {
+		subvolumegroup, err := c.cephFSSubvolumegroupCommand("ls", cephfs)
+		if err != nil {
+			return errors.Wrapf(err, "failed to list CephFilesytem '%s' subvolumegroups", cephfs)
+		}
+		if subvolumegroup != "" {
+			c.log.Info().Msgf("removing CephFS %s/%s subvolumegroup for CSI", c.lcmConfig.RookNamespace, cephfs)
+			_, err = c.cephFSSubvolumegroupCommand("rm", cephfs)
+			if err != nil {
+				return errors.Wrapf(err, "failed to remove CephFS '%s' subvolumegroups", cephfs)
+			}
+		}
+	}
+	c.log.Info().Msgf("removing CephFS %s/%s", c.lcmConfig.RookNamespace, cephfs)
+	err = c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Delete(c.context, cephfs, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to remove CephFilesytem '%s/%s'", c.lcmConfig.RookNamespace, cephfs)
+	}
+	delete(resourceUpdateTimestamps.cephConfigMap, fmt.Sprintf("mds.%s", cephfs))
+	return nil
 }
 
 func (c *cephDeploymentConfig) deleteSharedFilesystems() (bool, error) {
 	cephFsList, err := c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).List(c.context, metav1.ListOptions{})
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get cephFS list")
+		return false, errors.Wrap(err, "failed to get CephFilesytems list")
 	}
 	if len(cephFsList.Items) == 0 {
 		delete(resourceUpdateTimestamps.cephConfigMap, "mds")
@@ -172,34 +182,14 @@ func (c *cephDeploymentConfig) deleteSharedFilesystems() (bool, error) {
 	}
 	issues := 0
 	for _, cephFs := range cephFsList.Items {
-		c.log.Info().Msgf("removing CephFS %s/%s subvolumegroup for CSI", c.lcmConfig.RookNamespace, cephFs.Name)
-		subvolumegroup, err := c.cephFSSubvolumegroupCommand("ls", cephFs.Name)
+		err = c.removeCephFilesystem(cephFs.Name)
 		if err != nil {
-			c.log.Error().Err(err).Msgf("failed to list CephFS %s subvolumegroup", cephFs.Name)
-			issues++
-			continue
-		} else if subvolumegroup != "" {
-			_, err = c.cephFSSubvolumegroupCommand("rm", cephFs.Name)
-			if err != nil {
-				c.log.Error().Err(err).Msgf("failed to remove CephFS %s subvolumegroup", cephFs.Name)
-				issues++
-				continue
-			}
-		}
-
-		c.log.Info().Msgf("removing CephFS %s/%s", c.lcmConfig.RookNamespace, cephFs.Name)
-		err = c.api.Rookclientset.CephV1().CephFilesystems(c.lcmConfig.RookNamespace).Delete(c.context, cephFs.Name, metav1.DeleteOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			c.log.Error().Err(err).Msgf("failed to remove CephFS %s/%s", c.lcmConfig.RookNamespace, cephFs.Name)
+			c.log.Error().Err(err).Msgf("failed to remove CephFS '%s'", cephFs.Name)
 			issues++
 		}
-		delete(resourceUpdateTimestamps.cephConfigMap, fmt.Sprintf("mds.%s", cephFs.Name))
 	}
 	if issues > 0 {
-		return false, errors.New("some CephFS failed to delete")
+		return false, errors.New("some CephFilesytem(s) failed to delete")
 	}
 	return false, nil
 }

--- a/pkg/controller/deployment/shared_filesystem_test.go
+++ b/pkg/controller/deployment/shared_filesystem_test.go
@@ -113,8 +113,8 @@ func TestEnsureSharedFilesystem(t *testing.T) {
 				if strings.HasPrefix(e.Command, "ceph fs subvolumegroup -f json create") {
 					return "", "", nil
 				}
-				if strings.HasPrefix(e.Command, "ceph fs subvolumegroup -f json rm") {
-					return "", "", nil
+				if strings.HasPrefix(e.Command, "ceph fs ls -f json") {
+					return "[]", "", nil
 				}
 				return "", "", errors.Errorf("unexpected command '%v'", e.Command)
 			}
@@ -160,14 +160,14 @@ func TestEnsureCephFS(t *testing.T) {
 	delSharedFs := unitinputs.CephSharedFileSystemOk.DeepCopy()
 	delSharedFs.CephFS = make([]cephlcmv1alpha1.CephFS, 0)
 	tests := []struct {
-		name                  string
-		sharedFs              *cephlcmv1alpha1.CephSharedFilesystem
-		cephFilesystemList    *cephv1.CephFilesystemList
-		expectedCephFsList    *cephv1.CephFilesystemList
-		apiErrors             map[string]error
-		subvolumegroupCommand map[string]string
-		stateChanged          bool
-		expectedError         string
+		name               string
+		sharedFs           *cephlcmv1alpha1.CephSharedFilesystem
+		cephFilesystemList *cephv1.CephFilesystemList
+		expectedCephFsList *cephv1.CephFilesystemList
+		apiErrors          map[string]error
+		cliCommands        map[string]string
+		stateChanged       bool
+		expectedError      string
 		// to reflect ceph.conf changes
 		configUpdated bool
 	}{
@@ -182,17 +182,14 @@ func TestEnsureCephFS(t *testing.T) {
 			cephFilesystemList: unitinputs.CephFilesystemListEmpty.DeepCopy(),
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
 			apiErrors:          map[string]error{"get-cephfilesystems": errors.New("failed to get")},
-			expectedError:      "failed to get CephFS rook-ceph/test-cephfs: failed to get",
+			expectedError:      "error(s) during CephFilesytem(s) ensure: failed to get CephFilesytem 'rook-ceph/test-cephfs'",
 		},
 		{
 			name:               "create new cephfs",
 			sharedFs:           unitinputs.CephSharedFileSystemOk,
 			cephFilesystemList: unitinputs.CephFilesystemListEmpty.DeepCopy(),
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
-			subvolumegroupCommand: map[string]string{
-				"ls": "[]",
-			},
-			stateChanged: true,
+			stateChanged:       true,
 		},
 		{
 			name:               "fail to create new cephfs",
@@ -200,26 +197,27 @@ func TestEnsureCephFS(t *testing.T) {
 			cephFilesystemList: unitinputs.CephFilesystemListEmpty.DeepCopy(),
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
 			apiErrors:          map[string]error{"create-cephfilesystems": errors.New("failed to create")},
-			expectedError:      "failed to create CephFS rook-ceph/test-cephfs: failed to create",
+			expectedError:      "error(s) during CephFilesytem(s) ensure: failed to create CephFilesytem 'rook-ceph/test-cephfs'",
 		},
 		{
 			name:               "fail to create cephfs subvolumegroup",
 			sharedFs:           unitinputs.CephSharedFileSystemOk,
 			cephFilesystemList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{*unitinputs.TestCephFs.DeepCopy()}},
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
-			subvolumegroupCommand: map[string]string{
-				"ls":     "[]",
-				"create": "error",
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs":         "[]",
+				"ceph fs subvolumegroup -f json create test-cephfs csi": "error",
 			},
-			expectedError: "failed to create CephFS test-cephfs subvolumegroup: failed to run command 'ceph fs subvolumegroup -f json create test-cephfs csi' (stdErr: ENOENT: error): ceph fs subvolumegroup -f json create command failed",
+			expectedError: "error(s) during CephFilesytem(s) ensure: failed to create CephFS 'test-cephfs' subvolumegroup",
 		},
 		{
 			name:               "create only cephfs subvolumegroup",
 			sharedFs:           unitinputs.CephSharedFileSystemOk,
-			cephFilesystemList: unitinputs.CephFilesystemListEmpty.DeepCopy(),
+			cephFilesystemList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{*unitinputs.TestCephFs.DeepCopy()}},
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
-			subvolumegroupCommand: map[string]string{
-				"ls": "[]",
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs":         "[]",
+				"ceph fs subvolumegroup -f json create test-cephfs csi": "",
 			},
 			stateChanged: true,
 		},
@@ -228,29 +226,26 @@ func TestEnsureCephFS(t *testing.T) {
 			sharedFs:           unitinputs.CephSharedFileSystemOk,
 			cephFilesystemList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{*unitinputs.TestCephFs.DeepCopy()}},
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
-			subvolumegroupCommand: map[string]string{
-				"ls": "error",
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs": "error",
 			},
-			expectedError: "failed to list CephFS test-cephfs subvolumegroup: failed to run command 'ceph fs subvolumegroup -f json ls test-cephfs' (stdErr: ENOENT: error): ceph fs subvolumegroup -f json ls command failed",
+			expectedError: "error(s) during CephFilesytem(s) ensure: failed to list CephFS 'test-cephfs' subvolumegroups",
 		},
 		{
 			name:               "fail to update existing cephfs",
 			sharedFs:           updateSharedFs,
 			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
 			expectedCephFsList: unitinputs.CephFSList,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
-			},
-			apiErrors:     map[string]error{"update-cephfilesystems": errors.New("failed to update")},
-			expectedError: "failed to update CephFS rook-ceph/test-cephfs: failed to update",
+			apiErrors:          map[string]error{"update-cephfilesystems": errors.New("failed to update")},
+			expectedError:      "error(s) during CephFilesytem(s) ensure: failed to update CephFilesytem 'rook-ceph/test-cephfs'",
 		},
 		{
 			name:               "update existing cephfs",
 			sharedFs:           updateSharedFs,
 			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{*updatedCephFS}},
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs": `[{"name":"csi"}]`,
 			},
 			stateChanged: true,
 		},
@@ -269,8 +264,8 @@ func TestEnsureCephFS(t *testing.T) {
 					}(),
 				},
 			},
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs": `[{"name":"csi"}]`,
 			},
 			configUpdated: true,
 			stateChanged:  true,
@@ -280,49 +275,31 @@ func TestEnsureCephFS(t *testing.T) {
 			sharedFs:           unitinputs.CephSharedFileSystemOk.DeepCopy(),
 			cephFilesystemList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{unitinputs.TestCephFs}},
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs": `[{"name":"csi"}]`,
 			},
-		},
-		{
-			name:               "fail to check cephfs subvolumegroup presence for delete",
-			sharedFs:           delSharedFs,
-			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
-			expectedCephFsList: unitinputs.CephFSList,
-			subvolumegroupCommand: map[string]string{
-				"ls": "error",
-			},
-			expectedError: "failed to list CephFS test-cephfs subvolumegroup: failed to run command 'ceph fs subvolumegroup -f json ls test-cephfs' (stdErr: ENOENT: error): ceph fs subvolumegroup -f json ls command failed",
-		},
-		{
-			name:               "fail to remove cephfs subvolumegroup",
-			sharedFs:           delSharedFs,
-			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
-			expectedCephFsList: unitinputs.CephFSList,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
-				"rm": "error",
-			},
-			expectedError: "failed to remove CephFS test-cephfs subvolumegroup: failed to run command 'ceph fs subvolumegroup -f json rm test-cephfs csi' (stdErr: ENOENT: error): ceph fs subvolumegroup -f json rm command failed",
 		},
 		{
 			name:               "fail to delete existing cephfs",
 			sharedFs:           delSharedFs,
 			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
 			expectedCephFsList: unitinputs.CephFSList,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                `[{"name": "test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":     `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi": "error",
 			},
-			apiErrors:     map[string]error{"delete-cephfilesystems": errors.New("failed to delete")},
-			expectedError: "failed to delete CephFS rook-ceph/test-cephfs: failed to delete",
+			expectedError: "error(s) during CephFilesytem(s) ensure: failed to remove CephFilesytem 'test-cephfs'",
 		},
 		{
 			name:               "delete existing cephfs",
 			sharedFs:           delSharedFs,
 			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                `[{"name": "test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":     `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi": "",
 			},
 			stateChanged: true,
 		},
@@ -331,9 +308,9 @@ func TestEnsureCephFS(t *testing.T) {
 			sharedFs:           delSharedFs,
 			cephFilesystemList: unitinputs.CephFSList.DeepCopy(),
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[]`,
-				"rm": "error",
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                            `[{"name": "test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs": `[]`,
 			},
 			stateChanged: true,
 		},
@@ -354,8 +331,9 @@ func TestEnsureCephFS(t *testing.T) {
 					}(),
 				},
 			},
-			subvolumegroupCommand: map[string]string{
-				"ls": `[]`,
+			cliCommands: map[string]string{
+				"ceph fs subvolumegroup -f json ls test-cephfs":         "[]",
+				"ceph fs subvolumegroup -f json create test-cephfs csi": "",
 			},
 			stateChanged: true,
 		},
@@ -373,8 +351,11 @@ func TestEnsureCephFS(t *testing.T) {
 				},
 			},
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                   `[{"name":"test-cephfs"}, {"name":"second-test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":        `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi":    "",
+				"ceph fs subvolumegroup -f json ls second-test-cephfs": `[]`,
 			},
 			stateChanged: true,
 		},
@@ -392,8 +373,10 @@ func TestEnsureCephFS(t *testing.T) {
 				},
 			},
 			expectedCephFsList: &cephv1.CephFilesystemList{Items: []cephv1.CephFilesystem{*updatedCephFS}},
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                   `[{"name":"test-cephfs"}, {"name":"second-test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":        `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json ls second-test-cephfs": `[]`,
 			},
 			stateChanged: true,
 		},
@@ -403,7 +386,7 @@ func TestEnsureCephFS(t *testing.T) {
 			cephFilesystemList: unitinputs.CephFilesystemListEmpty.DeepCopy(),
 			expectedCephFsList: &unitinputs.CephFilesystemListEmpty,
 			apiErrors:          map[string]error{"create-cephfilesystems": errors.New("failed to create")},
-			expectedError:      "multiple errors during cephFS ensure",
+			expectedError:      "error(s) during CephFilesytem(s) ensure: failed to create CephFilesytem 'rook-ceph/test-cephfs', failed to create CephFilesytem 'rook-ceph/second-test-cephfs'",
 		},
 	}
 
@@ -419,20 +402,17 @@ func TestEnsureCephFS(t *testing.T) {
 				resourceUpdateTimestamps.cephConfigMap["mds.test-cephfs"] = "some-new-time"
 			}
 
+			var cliCommands map[string]string
+			if len(test.cliCommands) > 0 {
+				cliCommands = map[string]string{}
+			}
 			lcmcommon.RunPodCommandWithValidation = func(e lcmcommon.ExecConfig) (string, string, error) {
-				commands := map[string]string{
-					"ceph fs subvolumegroup -f json ls":     "ls",
-					"ceph fs subvolumegroup -f json create": "create",
-					"ceph fs subvolumegroup -f json rm":     "rm",
-				}
-				for cmd, op := range commands {
-					if strings.HasPrefix(e.Command, cmd) {
-						if test.subvolumegroupCommand[op] == "error" {
-							t.Logf("ERROR ON CREATE")
-							return "", "ENOENT: error", errors.Errorf("%s command failed", cmd)
-						}
-						return test.subvolumegroupCommand[op], "", nil
+				if v, ok := test.cliCommands[e.Command]; ok {
+					cliCommands[e.Command] = v
+					if v == "error" {
+						return "", "ENOENT: error", errors.Errorf("%s command failed", e.Command)
 					}
+					return v, "", nil
 				}
 				return "", "", errors.Errorf("unexpected command '%v'", e.Command)
 			}
@@ -455,6 +435,7 @@ func TestEnsureCephFS(t *testing.T) {
 				assert.Nil(t, err)
 			}
 			assert.Equal(t, test.stateChanged, changed)
+			assert.Equal(t, test.cliCommands, cliCommands)
 			assert.Equal(t, test.expectedCephFsList, test.cephFilesystemList)
 
 			// revert updating timestamps of config is necessary
@@ -471,56 +452,86 @@ func TestEnsureCephFS(t *testing.T) {
 }
 
 func TestDeleteSharedFilesystems(t *testing.T) {
-	resourceUpdateTimestamps = updateTimestamps{
-		cephConfigMap: map[string]string{
-			"mds": "some-time",
-		},
-	}
 	tests := []struct {
-		name                  string
-		cephDpl               *cephlcmv1alpha1.CephDeployment
-		cephFsList            *cephv1.CephFilesystemList
-		expectedList          *cephv1.CephFilesystemList
-		removed               bool
-		apiErrors             map[string]error
-		subvolumegroupCommand map[string]string
-		expectedError         string
+		name          string
+		cephDpl       *cephlcmv1alpha1.CephDeployment
+		cephFsList    *cephv1.CephFilesystemList
+		expectedList  *cephv1.CephFilesystemList
+		removed       bool
+		apiErrors     map[string]error
+		cliCommands   map[string]string
+		expectedError string
 	}{
 		{
-			name:    "fail list cephfs",
-			cephDpl: &unitinputs.BaseCephDeployment,
-			subvolumegroupCommand: map[string]string{
-				"ls": "[]",
-			},
-			expectedError: "failed to get cephFS list: failed to list cephfilesystems",
+			name:          "fail list cephfs",
+			cephDpl:       &unitinputs.BaseCephDeployment,
+			cliCommands:   map[string]string{},
+			expectedError: "failed to get CephFilesytems list: failed to list cephfilesystems",
 		},
 		{
-			name:         "failed to delete ceph fs",
-			cephDpl:      &unitinputs.BaseCephDeployment,
-			cephFsList:   unitinputs.CephFSList.DeepCopy(),
-			expectedList: unitinputs.CephFSList,
-			apiErrors:    map[string]error{"delete-cephfilesystems": errors.New("failed to delete")},
-			subvolumegroupCommand: map[string]string{
-				"ls": "[]",
+			name:       "failed to check ceph fs in cluster",
+			cephDpl:    &unitinputs.BaseCephDeployment,
+			cephFsList: unitinputs.CephFSList.DeepCopy(),
+			cliCommands: map[string]string{
+				"ceph fs ls -f json": "error",
 			},
-			expectedError: "some CephFS failed to delete",
+			expectedList:  unitinputs.CephFSList,
+			expectedError: "some CephFilesytem(s) failed to delete",
 		},
 		{
-			name:    "shared filesystems removing",
-			cephDpl: &unitinputs.BaseCephDeployment,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
-				"rm": "",
+			name:       "failed to delete cephfilesystem",
+			cephDpl:    &unitinputs.BaseCephDeployment,
+			cephFsList: unitinputs.CephFSList.DeepCopy(),
+			apiErrors:  map[string]error{"delete-cephfilesystems": errors.New("failed to delete")},
+			cliCommands: map[string]string{
+				"ceph fs ls -f json": `[]`,
 			},
-			cephFsList:   unitinputs.CephFSList.DeepCopy(),
+			expectedList:  unitinputs.CephFSList,
+			expectedError: "some CephFilesytem(s) failed to delete",
+		},
+		{
+			name:       "fail to check cephfs subvolumegroup on cephfs removing",
+			cephDpl:    &unitinputs.BaseCephDeployment,
+			cephFsList: unitinputs.CephFSList.DeepCopy(),
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                            `[{"name":"test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs": "error",
+			},
+			expectedError: "some CephFilesytem(s) failed to delete",
+			expectedList:  unitinputs.CephFSList,
+		},
+		{
+			name:       "fail to delete cephfs subvolumegroup on cephfs removing",
+			cephFsList: unitinputs.CephFSList.DeepCopy(),
+			cephDpl:    &unitinputs.BaseCephDeployment,
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                `[{"name":"test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":     `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi": "error",
+			},
+			expectedList:  unitinputs.CephFSList,
+			expectedError: "some CephFilesytem(s) failed to delete",
+		},
+		{
+			name:       "shared filesystems removing",
+			cephDpl:    &unitinputs.BaseCephDeployment,
+			cephFsList: unitinputs.CephFSList.DeepCopy(),
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                `[{"name":"test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":     `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi": "",
+			},
 			expectedList: &unitinputs.CephFilesystemListEmpty,
 		},
 		{
 			name:    "multiple shared filesystems removing",
 			cephDpl: &unitinputs.BaseCephDeployment,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
-				"rm": "",
+			cliCommands: map[string]string{
+				"ceph fs ls -f json":                                       `[{"name":"test-cephfs"}, {"name":"second-test-cephfs"}]`,
+				"ceph fs subvolumegroup -f json ls test-cephfs":            `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm test-cephfs csi":        "",
+				"ceph fs subvolumegroup -f json ls second-test-cephfs":     `[{"name":"csi"}]`,
+				"ceph fs subvolumegroup -f json rm second-test-cephfs csi": "",
 			},
 			cephFsList: &cephv1.CephFilesystemList{
 				Items: []cephv1.CephFilesystem{
@@ -535,36 +546,12 @@ func TestDeleteSharedFilesystems(t *testing.T) {
 			expectedList: &unitinputs.CephFilesystemListEmpty,
 		},
 		{
-			name:    "fail to check cephfs subvolumegroup on cephfs removing",
-			cephDpl: &unitinputs.BaseCephDeployment,
-			subvolumegroupCommand: map[string]string{
-				"ls": "error",
-			},
-			cephFsList:    unitinputs.CephFSList.DeepCopy(),
-			expectedError: "some CephFS failed to delete",
-			expectedList:  unitinputs.CephFSList,
-		},
-		{
-			name:    "fail to delete cephfs subvolumegroup on cephfs removing",
-			cephDpl: &unitinputs.BaseCephDeployment,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[{"name":"csi"}]`,
-				"rm": "error",
-			},
-			cephFsList:    unitinputs.CephFSList.DeepCopy(),
-			expectedError: "some CephFS failed to delete",
-			expectedList:  unitinputs.CephFSList,
-		},
-		{
 			name:         "nothing to remove",
 			cephDpl:      &unitinputs.BaseCephDeployment,
 			cephFsList:   unitinputs.CephFilesystemListEmpty.DeepCopy(),
 			expectedList: &unitinputs.CephFilesystemListEmpty,
-			subvolumegroupCommand: map[string]string{
-				"ls": `[]`,
-				"rm": "",
-			},
-			removed: true,
+			cliCommands:  map[string]string{},
+			removed:      true,
 		},
 	}
 
@@ -572,27 +559,31 @@ func TestDeleteSharedFilesystems(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := fakeDeploymentConfig(&deployConfig{cephDpl: test.cephDpl}, nil)
+			cliCommands := map[string]string{}
+
 			lcmcommon.RunPodCommandWithValidation = func(e lcmcommon.ExecConfig) (string, string, error) {
-				commands := map[string]string{
-					"ceph fs subvolumegroup -f json ls": "ls",
-					"ceph fs subvolumegroup -f json rm": "rm",
-				}
-				for cmd, op := range commands {
-					if strings.HasPrefix(e.Command, cmd) {
-						if test.subvolumegroupCommand[op] == "error" {
-							t.Logf("ERROR ON CREATE")
-							return "", "ENOENT: error", errors.Errorf("%s command failed", cmd)
-						}
-						return test.subvolumegroupCommand[op], "", nil
+				if v, ok := test.cliCommands[e.Command]; ok {
+					cliCommands[e.Command] = v
+					if v == "error" {
+						return "", "ENOENT: error", errors.Errorf("%s command failed", e.Command)
 					}
+					return v, "", nil
 				}
 				return "", "", errors.Errorf("unexpected command '%v'", e.Command)
 			}
 
-			inputResources := map[string]runtime.Object{"cephfilesystems": test.cephFsList}
-			if test.cephFsList == nil {
-				inputResources = nil
+			resourceUpdateTimestamps = updateTimestamps{
+				cephConfigMap: map[string]string{},
 			}
+
+			inputResources := map[string]runtime.Object{}
+			if test.cephFsList != nil {
+				inputResources["cephfilesystems"] = test.cephFsList
+				for _, fs := range test.cephFsList.Items {
+					resourceUpdateTimestamps.cephConfigMap["mds."+fs.Name] = "some-time"
+				}
+			}
+
 			faketestclients.FakeReaction(c.api.Rookclientset, "list", []string{"cephfilesystems"}, inputResources, nil)
 			faketestclients.FakeReaction(c.api.Rookclientset, "delete", []string{"cephfilesystems"}, inputResources, test.apiErrors)
 
@@ -600,11 +591,16 @@ func TestDeleteSharedFilesystems(t *testing.T) {
 			if test.expectedError != "" {
 				assert.NotNil(t, err)
 				assert.Equal(t, test.expectedError, err.Error())
+				if test.cephFsList != nil {
+					assert.NotEqual(t, len(resourceUpdateTimestamps.cephConfigMap), 0)
+				}
 			} else {
 				assert.Nil(t, err)
+				assert.Equal(t, len(resourceUpdateTimestamps.cephConfigMap), 0)
 			}
 			assert.Equal(t, test.removed, done)
 			assert.Equal(t, test.expectedList, test.cephFsList)
+			assert.Equal(t, test.cliCommands, cliCommands)
 			faketestclients.CleanupFakeClientReactions(c.api.Rookclientset)
 		})
 	}

--- a/pkg/controller/deployment/utils.go
+++ b/pkg/controller/deployment/utils.go
@@ -200,6 +200,27 @@ func (c *cephDeploymentConfig) getCephVersions() (*lcmcommon.CephVersions, error
 	return &cephVersions, nil
 }
 
+func (c *cephDeploymentConfig) cephFsPresent(cephFsName string) (bool, error) {
+	command := "ceph fs ls -f json"
+	output, err := lcmcommon.RunCephToolboxCLI(c.context, c.api.Kubeclientset, c.api.Config, c.lcmConfig.RookNamespace, command)
+	if err != nil {
+		return false, err
+	}
+	var cephFsLs []struct {
+		Name string `json:"name"`
+	}
+	err = json.Unmarshal([]byte(output), &cephFsLs)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to parse 'ceph fs ls' command output")
+	}
+	for _, cephFs := range cephFsLs {
+		if cephFs.Name == cephFsName {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (c *cephDeploymentConfig) cephFSSubvolumegroupCommand(op string, cephFsName string) (string, error) {
 	command := fmt.Sprintf("ceph fs subvolumegroup -f json %s %s", op, cephFsName)
 	if op == "create" || op == "rm" {


### PR DESCRIPTION
If CephFilesystem object is present, but cephFS itself is not created no need to try remove subvolumegroup and remove only CephFilesystem.

(cherry picked from commit e11f90a2d1a380bd3e54af1b81b648e45fb564f4)

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>