### PR TITLE
Do not set by default deviceClass in e2e config for cephfs test

### DIFF
--- a/test/e2e/cephfs_test.go
+++ b/test/e2e/cephfs_test.go
@@ -209,6 +209,10 @@ func TestCephFS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	poolDefaultClass := f.GetDefaultPoolDeviceClass(cd)
+	if poolDefaultClass == "" {
+		t.Fatal("failed to find default pool")
+	}
 	toUpdate := false
 	if cd.Spec.SharedFilesystem == nil {
 		cd.Spec.SharedFilesystem = &cephlcmv1alpha1.CephSharedFilesystem{}
@@ -217,6 +221,24 @@ func TestCephFS(t *testing.T) {
 		newFsSpecCasted, err := newCephFS.GetSpec()
 		if err != nil {
 			t.Fatal(err)
+		}
+		deviceClassUpdated := false
+		if newFsSpecCasted.MetadataPool.DeviceClass == "" {
+			newFsSpecCasted.MetadataPool.DeviceClass = poolDefaultClass
+			deviceClassUpdated = true
+		}
+		for idx, dp := range newFsSpecCasted.DataPools {
+			if dp.DeviceClass == "" {
+				newFsSpecCasted.DataPools[idx].DeviceClass = poolDefaultClass
+				deviceClassUpdated = true
+			}
+		}
+		if deviceClassUpdated {
+			newFsSpec, err := cephlcmv1alpha1.DecodeStructToRaw(newFsSpecCasted)
+			if err != nil {
+				t.Fatal(err)
+			}
+			newCephFS.FsSpec.Raw = newFsSpec
 		}
 		found := false
 		for idx, cephFS := range cd.Spec.SharedFilesystem.Filesystems {

--- a/test/e2e/testconfigs/cephfs-multiple.yaml
+++ b/test/e2e/testconfigs/cephfs-multiple.yaml
@@ -12,12 +12,10 @@ testSettings:
                 "dataPools": [{
                   "name": "cephfs-pool",
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 }],
                 "metadataPool": {
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 },
                 "metadataServer": {
@@ -32,12 +30,10 @@ testSettings:
                 "dataPools": [{
                   "name": "test-datapool",
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 }],
                 "metadataPool": {
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 },
                 "metadataServer": {"activeCount": 1 }

--- a/test/e2e/testconfigs/cephfs.yaml
+++ b/test/e2e/testconfigs/cephfs.yaml
@@ -12,12 +12,10 @@ testSettings:
                 "dataPools": [{
                   "name": "cephfs-pool",
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 }],
                 "metadataPool": {
                   "failureDomain": "host",
-                  "deviceClass": "hdd",
                   "replicated": {"size": 2 }
                 },
                 "metadataServer": {


### PR DESCRIPTION
If deviceClass is not set by default, use deviceClass of default pool. To aviod issues between different envs with different deviceClasses.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>