### PR TITLE
Do not set by default deviceClass in e2e config for cephfs test

### DIFF
--- a/test/e2e/cephfs_test.go
+++ b/test/e2e/cephfs_test.go
@@ -207,10 +207,22 @@ func TestCephFS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	poolDefaultClass := f.GetDefaultPoolDeviceClass(cd)
+	if poolDefaultClass == "" {
+		t.Fatal("failed to find default pool")
+	}
 	toUpdate := false
 	if cd.Spec.SharedFilesystem != nil {
 		for _, newCephFS := range sharedFS.CephFS {
 			found := false
+			if newCephFS.MetadataPool.DeviceClass == "" {
+				newCephFS.MetadataPool.DeviceClass = poolDefaultClass
+			}
+			for idx, dp := range newCephFS.DataPools {
+				if dp.DeviceClass == "" {
+					newCephFS.DataPools[idx].DeviceClass = poolDefaultClass
+				}
+			}
 			for idx, cephFS := range cd.Spec.SharedFilesystem.CephFS {
 				if cephFS.Name == newCephFS.Name {
 					f.TF.Log.Warn().Msgf("found present CephFS with the same name as for e2e test: %s", cephFS.Name)

--- a/test/e2e/testconfigs/cephfs-multiple.yaml
+++ b/test/e2e/testconfigs/cephfs-multiple.yaml
@@ -11,12 +11,10 @@ testSettings:
               "dataPools": [{
                 "name": "cephfs-pool",
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               }],
               "metadataPool": {
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               },
               "metadataServer": {
@@ -29,12 +27,10 @@ testSettings:
               "dataPools": [{
                 "name": "test-datapool",
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               }],
               "metadataPool": {
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               },
               "metadataServer": {"activeCount": 1 }

--- a/test/e2e/testconfigs/cephfs.yaml
+++ b/test/e2e/testconfigs/cephfs.yaml
@@ -11,12 +11,10 @@ testSettings:
               "dataPools": [{
                 "name": "cephfs-pool",
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               }],
               "metadataPool": {
                 "failureDomain": "host",
-                "deviceClass": "hdd",
                 "replicated": {"size": 2 }
               },
               "metadataServer": {


### PR DESCRIPTION
If deviceClass is not set by default, use deviceClass of default pool. To aviod issues between different envs with different deviceClasses.

(cherry picked from commit 529c26d)

Signed-Off-By: Denis Egorenko degorenko@mirantis.com