### PR TITLE
Allow to set custom drain request and drain ready labels

### DIFF
--- a/charts/pelagia-ceph/templates/common.yaml
+++ b/charts/pelagia-ceph/templates/common.yaml
@@ -37,6 +37,12 @@ data:
   {{- if (.Values.lcmConfig.cephDaemonsetLabelExclude) }}
   DEPLOYMENT_LABEL_TO_EXCLUDE_CEPH_DAEMONSETS: {{ .Values.lcmConfig.cephDaemonsetLabelExclude }}
   {{- end }}
+  {{- if (.Values.cephDeployment.drainRequestLabelKey) }}
+  DEPLOYMENT_DRAIN_REQUEST_LABEL_KEY: {{ .Values.cephDeployment.drainRequestLabelKey }}
+  {{- end }}
+  {{- if (.Values.cephDeployment.drainReadyLabelKey) }}
+  DEPLOYMENT_DRAIN_READY_LABEL_KEY: {{ .Values.cephDeployment.drainReadyLabelKey }}
+  {{- end }}
 {{- end }}
 {{- if .Values.global.namespace }}
 ---

--- a/charts/pelagia-ceph/values.yaml
+++ b/charts/pelagia-ceph/values.yaml
@@ -12,6 +12,9 @@ cephDeployment:
   netpolEnabled: true
   installSharedNamespace: true
   openstackSharedNamespace: openstack-ceph-shared
+  # drain request and readiness label keys
+  drainRequestLabelKey: ""
+  drainReadyLabelKey: ""
 lcmConfig:
   rgwPublicAccessServiceSelector: "external_access=rgw"
   diskDaemonPortParameter: 9999

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -98,6 +98,10 @@ type DeployParams struct {
 	MultisiteCabundleSecretRef string
 	// excluding label to place ceph daemonsets
 	CephDaemonsetPlacementLabelExclude string
+	// drain request label for nodes
+	DrainRequestLabelKey string
+	// drain ready label for nodes
+	DrainReadyLabelKey string
 }
 
 type ControlParams string
@@ -149,7 +153,9 @@ var (
 		OsdPgRebalanceTimeout: 30 * time.Minute,
 	}
 	defaultDeployParams = DeployParams{
-		LogLevel: zerolog.InfoLevel,
+		LogLevel:             zerolog.InfoLevel,
+		DrainRequestLabelKey: "kaas.mirantis.com/lcm-drained",
+		DrainReadyLabelKey:   "kaas.mirantis.com/csi-drained",
 	}
 )
 
@@ -184,6 +190,8 @@ var (
 	cephDplOpenstackCephSharedNs     = "DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE"
 	cephDplMultisiteCabundleRef      = "DEPLOYMENT_MULTISITE_CABUNDLE_SECRET"
 	cephDplCephDaemonsetLabelExclude = "DEPLOYMENT_LABEL_TO_EXCLUDE_CEPH_DAEMONSETS"
+	cephDplDrainRequestLabelKeyName  = "DEPLOYMENT_DRAIN_REQUEST_LABEL_KEY"
+	cephDplDrainReadyLabelKeyName    = "DEPLOYMENT_DRAIN_READY_LABEL_KEY"
 )
 
 func dropConfiguration(namespace string) {
@@ -325,6 +333,16 @@ func loadCephDeploymentConfiguration(objLog zerolog.Logger, configData map[strin
 	if multisiteCaBundle, present := configData[cephDplMultisiteCabundleRef]; present {
 		objLog.Debug().Msgf(debugMsgTmpl, cephDplMultisiteCabundleRef, multisiteCaBundle)
 		newCephDplConfig.MultisiteCabundleSecretRef = multisiteCaBundle
+	}
+
+	if drainRequestLabel, present := configData[cephDplDrainRequestLabelKeyName]; present {
+		objLog.Debug().Msgf(debugMsgTmpl, cephDplDrainRequestLabelKeyName, drainRequestLabel)
+		newCephDplConfig.DrainRequestLabelKey = drainRequestLabel
+	}
+
+	if drainReadyLabel, present := configData[cephDplDrainReadyLabelKeyName]; present {
+		objLog.Debug().Msgf(debugMsgTmpl, cephDplDrainReadyLabelKeyName, drainReadyLabel)
+		newCephDplConfig.DrainReadyLabelKey = drainReadyLabel
 	}
 
 	return &newCephDplConfig

--- a/pkg/controller/config/controller_test.go
+++ b/pkg/controller/config/controller_test.go
@@ -129,6 +129,8 @@ func TestInitReconcile(t *testing.T) {
 					"DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE":  "custom-openstack-ns",
 					"DEPLOYMENT_MULTISITE_CABUNDLE_SECRET":        "secret-with-ca-bundle",
 					"DEPLOYMENT_LABEL_TO_EXCLUDE_CEPH_DAEMONSETS": "no-ceph=true",
+					"DEPLOYMENT_DRAIN_REQUEST_LABEL_KEY":          "custom-label/drain-request",
+					"DEPLOYMENT_DRAIN_READY_LABEL_KEY":            "custom-label/csi-drain-ready",
 				},
 			},
 			controlParams:  ControlParamsAll,
@@ -161,6 +163,8 @@ func TestInitReconcile(t *testing.T) {
 						OpenstackCephSharedNamespace:       "custom-openstack-ns",
 						MultisiteCabundleSecretRef:         "secret-with-ca-bundle",
 						CephDaemonsetPlacementLabelExclude: "no-ceph=true",
+						DrainRequestLabelKey:               "custom-label/drain-request",
+						DrainReadyLabelKey:                 "custom-label/csi-drain-ready",
 					}
 					return newConfig
 				}(),

--- a/pkg/controller/deployment/const.go
+++ b/pkg/controller/deployment/const.go
@@ -46,10 +46,8 @@ const (
 	rookRBDProvisionerName    = "rook-ceph.rbd.csi.ceph.com"
 	rookCephFSProvisionerName = "rook-ceph.cephfs.csi.ceph.com"
 
-	cephDaemonsetLabel        = "ceph-daemonset-available-node"
-	cephDaemonsetDrainRequest = "kaas.mirantis.com/lcm-drained"
-	cephDaemonsetDrainReady   = "kaas.mirantis.com/csi-drained"
-	cephVolumeAttachmentType  = "rook-ceph.rbd.csi.ceph.com"
+	cephDaemonsetLabel       = "ceph-daemonset-available-node"
+	cephVolumeAttachmentType = "rook-ceph.rbd.csi.ceph.com"
 
 	cephKubeTopologyLabelTemplate = "cephdpl-prev-%s"
 	nodeWithOSDSelectorTemplate   = "app=rook-ceph-osd,failure-domain=%s"

--- a/pkg/controller/deployment/csi_evict.go
+++ b/pkg/controller/deployment/csi_evict.go
@@ -41,7 +41,6 @@ var (
 	waitForDaemonsetsPodsInterval     = 5 * time.Second
 )
 
-// TODO: labels are used from kaas maintenance - ?
 func (c *cephDeploymentConfig) ensureDaemonsetLabels() {
 	c.log.Debug().Msg("run check daemonsets label ensure")
 	nodes, err := c.api.Kubeclientset.CoreV1().Nodes().List(c.context, metav1.ListOptions{})
@@ -50,8 +49,8 @@ func (c *cephDeploymentConfig) ensureDaemonsetLabels() {
 		return
 	}
 	for _, node := range nodes.Items {
-		if node.Annotations != nil && node.Annotations[cephDaemonsetDrainRequest] == "true" {
-			c.log.Info().Msgf("ceph daemonset ensure: found lcm drain request '%s' for node %s", cephDaemonsetDrainRequest, node.Name)
+		if node.Annotations != nil && node.Annotations[c.lcmConfig.DeployParams.DrainRequestLabelKey] == "true" {
+			c.log.Info().Msgf("ceph daemonset ensure: found lcm drain request '%s' for node %s", c.lcmConfig.DeployParams.DrainRequestLabelKey, node.Name)
 			if node.Labels[cephDaemonsetLabel] != "" {
 				c.log.Info().Msgf("ceph daemonset ensure: found label '%s' to delete", cephDaemonsetLabel)
 				_, err = c.checkCSIVolumes(node.Name, true)
@@ -82,17 +81,17 @@ func (c *cephDeploymentConfig) ensureDaemonsetLabels() {
 				c.log.Error().Err(err).Msgf("ceph daemonsets label ensure failed: daemonset pods not evicted from %s node", node.Name)
 				continue
 			}
-			c.log.Info().Msgf("ceph daemonset ensure: setting annotation '%s' for %s node", cephDaemonsetDrainReady, node.Name)
+			c.log.Info().Msgf("ceph daemonset ensure: setting annotation '%s' for %s node", c.lcmConfig.DeployParams.DrainReadyLabelKey, node.Name)
 			nodeAnnotationsCsi, err := c.api.Kubeclientset.CoreV1().Nodes().Get(c.context, node.Name, metav1.GetOptions{})
 			if err != nil {
 				c.log.Error().Err(err).Msgf("ceph daemonsets label ensure failed: failed to get node %s", node.Name)
 				continue
 			}
-			if nodeAnnotationsCsi.Annotations[cephDaemonsetDrainReady] != "true" {
-				nodeAnnotationsCsi.Annotations[cephDaemonsetDrainReady] = "true"
+			if nodeAnnotationsCsi.Annotations[c.lcmConfig.DeployParams.DrainReadyLabelKey] != "true" {
+				nodeAnnotationsCsi.Annotations[c.lcmConfig.DeployParams.DrainReadyLabelKey] = "true"
 				_, err = c.api.Kubeclientset.CoreV1().Nodes().Update(c.context, nodeAnnotationsCsi, metav1.UpdateOptions{})
 				if err != nil {
-					c.log.Error().Err(err).Msgf("ceph daemonsets label ensure failed: failed to add drain ready annotation %s to node %s", cephDaemonsetDrainReady, node.Name)
+					c.log.Error().Err(err).Msgf("ceph daemonsets label ensure failed: failed to add drain ready annotation %s to node %s", c.lcmConfig.DeployParams.DrainReadyLabelKey, node.Name)
 					continue
 				}
 			}


### PR DESCRIPTION
Drain labels are used to be sure that CSI are evacuated properly and no hanged mounts on a node. Allow to specify custom labels for that.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>