### PR TITLE
Drop deprecated lcmconfig parameter for caBundle

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -92,10 +92,6 @@ type DeployParams struct {
 	NetPolEnabled bool
 	// namespace for sharing secrets between openstack and ceph
 	OpenstackCephSharedNamespace string
-	// TODO: deprecated, since can be replaced by CaBundleRef directly
-	// for related cephobjectstore config
-	// secret with cabundle for multisite public access between zones
-	MultisiteCabundleSecretRef string
 	// excluding label to place ceph daemonsets
 	CephDaemonsetPlacementLabelExclude string
 	// drain request label for nodes
@@ -188,7 +184,6 @@ var (
 	cephDplRookImage                 = "DEPLOYMENT_ROOK_IMAGE"
 	cephDplNetPolEnabled             = "DEPLOYMENT_NETPOL_ENABLED"
 	cephDplOpenstackCephSharedNs     = "DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE"
-	cephDplMultisiteCabundleRef      = "DEPLOYMENT_MULTISITE_CABUNDLE_SECRET"
 	cephDplCephDaemonsetLabelExclude = "DEPLOYMENT_LABEL_TO_EXCLUDE_CEPH_DAEMONSETS"
 	cephDplDrainRequestLabelKeyName  = "DEPLOYMENT_DRAIN_REQUEST_LABEL_KEY"
 	cephDplDrainReadyLabelKeyName    = "DEPLOYMENT_DRAIN_READY_LABEL_KEY"
@@ -328,11 +323,6 @@ func loadCephDeploymentConfiguration(objLog zerolog.Logger, configData map[strin
 	if openstackCephNs, present := configData[cephDplOpenstackCephSharedNs]; present {
 		objLog.Debug().Msgf(debugMsgTmpl, cephDplOpenstackCephSharedNs, openstackCephNs)
 		newCephDplConfig.OpenstackCephSharedNamespace = openstackCephNs
-	}
-
-	if multisiteCaBundle, present := configData[cephDplMultisiteCabundleRef]; present {
-		objLog.Debug().Msgf(debugMsgTmpl, cephDplMultisiteCabundleRef, multisiteCaBundle)
-		newCephDplConfig.MultisiteCabundleSecretRef = multisiteCaBundle
 	}
 
 	if drainRequestLabel, present := configData[cephDplDrainRequestLabelKeyName]; present {

--- a/pkg/controller/config/controller_test.go
+++ b/pkg/controller/config/controller_test.go
@@ -127,7 +127,6 @@ func TestInitReconcile(t *testing.T) {
 					"TASK_OSD_PG_REBALANCE_TIMEOUT_MIN":           "10",
 					"TASK_ALLOW_REMOVE_MANUALLY_CREATED_LVMS":     "true",
 					"DEPLOYMENT_OPENSTACK_CEPH_SHARED_NAMESPACE":  "custom-openstack-ns",
-					"DEPLOYMENT_MULTISITE_CABUNDLE_SECRET":        "secret-with-ca-bundle",
 					"DEPLOYMENT_LABEL_TO_EXCLUDE_CEPH_DAEMONSETS": "no-ceph=true",
 					"DEPLOYMENT_DRAIN_REQUEST_LABEL_KEY":          "custom-label/drain-request",
 					"DEPLOYMENT_DRAIN_READY_LABEL_KEY":            "custom-label/csi-drain-ready",
@@ -161,7 +160,6 @@ func TestInitReconcile(t *testing.T) {
 					newConfig.DeployParams = &DeployParams{
 						LogLevel:                           2,
 						OpenstackCephSharedNamespace:       "custom-openstack-ns",
-						MultisiteCabundleSecretRef:         "secret-with-ca-bundle",
 						CephDaemonsetPlacementLabelExclude: "no-ceph=true",
 						DrainRequestLabelKey:               "custom-label/drain-request",
 						DrainReadyLabelKey:                 "custom-label/csi-drain-ready",


### PR DESCRIPTION
Since v2 Pelagia it is possible to specify required caBundle ref directly in spec, parameter is not needed anymore.

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>