### PR TITLE
Bump go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mirantis/pelagia/v2
 
-go 1.26.5
+go 1.26.6
 
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1


### PR DESCRIPTION
(cherry picked from commit a24c7ccf6273a9c4bcac7627f6d79e05ff79117a)

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>