### PR TITLE
Bump Ceph Tentacle to v20.2.3

### DIFF
--- a/charts/pelagia-ceph/values.yaml
+++ b/charts/pelagia-ceph/values.yaml
@@ -97,7 +97,7 @@ images:
   ceph:
     repository: pelagia/ceph
     tag:
-      latest: &latestImageCeph v20.2.2-3.release
+      latest: &latestImageCeph v20.2.3-1.release
       squid: v19.2.4-4.cve
       tentacle: *latestImageCeph
 

--- a/pkg/common/version.go
+++ b/pkg/common/version.go
@@ -44,7 +44,7 @@ var (
 		Name:            "Tentacle",
 		MajorVersion:    "v20.2",
 		Order:           20,
-		SupportedMinors: []string{"0", "1", "2"},
+		SupportedMinors: []string{"0", "1", "2", "3"},
 	}
 	Squid = &CephVersion{
 		Name:            "Squid",

--- a/pkg/common/version_test.go
+++ b/pkg/common/version_test.go
@@ -74,7 +74,7 @@ func TestGetCephVersionByReleaseName(t *testing.T) {
 				Name:            "Tentacle",
 				MajorVersion:    "v20.2",
 				Order:           20,
-				SupportedMinors: []string{"0", "1", "2"},
+				SupportedMinors: []string{"0", "1", "2", "3"},
 			},
 		},
 		{
@@ -84,7 +84,7 @@ func TestGetCephVersionByReleaseName(t *testing.T) {
 				Name:            "Tentacle",
 				MajorVersion:    "v20.2",
 				Order:           20,
-				SupportedMinors: []string{"0", "1", "2"},
+				SupportedMinors: []string{"0", "1", "2", "3"},
 			},
 		},
 		{
@@ -146,8 +146,8 @@ func TestParseCephVersion(t *testing.T) {
 		},
 		{
 			name:          "check ceph version tentacle- image is not in list supported minors",
-			cephVersion:   "ceph version 20.2.20 (safmsdgldfhglkfdhdlstet) custom",
-			expectedError: "specified Ceph version 'v20.2.20' is not supported. Please use one of: [v20.2.0 v20.2.1 v20.2.2]",
+			cephVersion:   "ceph version 20.2.30 (safmsdgldfhglkfdhdlstet) custom",
+			expectedError: "specified Ceph version 'v20.2.30' is not supported. Please use one of: [v20.2.0 v20.2.1 v20.2.2 v20.2.3]",
 		},
 		{
 			name:        "check ceph version - tentacle image version passed",

--- a/pkg/controller/deployment/controller_test.go
+++ b/pkg/controller/deployment/controller_test.go
@@ -609,7 +609,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 10,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:31+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -663,7 +663,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 10,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:32+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -761,7 +761,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 10,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:33+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -770,7 +770,7 @@ func TestReconcile(t *testing.T) {
 			name: "reconcile cephdeployment - update non-mosk ceph cluster",
 			inputResources: map[string]runtime.Object{
 				"cephdeployments": &cephlcmv1alpha1.CephDeploymentList{Items: []cephlcmv1alpha1.CephDeployment{
-					*unitinputs.GetUpdatedClusterVersionCephDeploy(unitinputs.CephDeployNonMosk.DeepCopy(), "v20.2.2")}},
+					*unitinputs.GetUpdatedClusterVersionCephDeploy(unitinputs.CephDeployNonMosk.DeepCopy(), "v20.2.3")}},
 				"cephdeploymentsecrets":      &cephlcmv1alpha1.CephDeploymentSecretList{Items: []cephlcmv1alpha1.CephDeploymentSecret{*unitinputs.EmptyCephSecret}},
 				"cephdeploymenthealths":      &cephlcmv1alpha1.CephDeploymentHealthList{Items: []cephlcmv1alpha1.CephDeploymentHealth{unitinputs.CephDeploymentHealth}},
 				"cephdeploymentmaintenances": unitinputs.CephDeploymentMaintenanceListIdle,
@@ -788,7 +788,7 @@ func TestReconcile(t *testing.T) {
 				"cephclusters": &cephv1.CephClusterList{Items: []cephv1.CephCluster{
 					func() cephv1.CephCluster {
 						cluster := unitinputs.TestCephCluster.DeepCopy()
-						cluster.Spec.CephVersion.Image = "fake/fake:v20.2.2-0"
+						cluster.Spec.CephVersion.Image = "fake/fake:v20.2.3-0"
 						return *cluster
 					}(),
 				}},
@@ -810,7 +810,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 10,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:34+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -914,7 +914,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 0,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:36+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -1040,7 +1040,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 0,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:39+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -1112,7 +1112,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 0,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:40+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},
@@ -1144,7 +1144,7 @@ func TestReconcile(t *testing.T) {
 					Result:                  "Succeed",
 					LastValidatedGeneration: 0,
 				},
-				ClusterVersion: "v20.2.2",
+				ClusterVersion: "v20.2.3",
 				LastRun:        "2021-08-15T14:30:41+04:00",
 				ObjectsRefs:    unitinputs.CephDeploymentObjectsRefs,
 			},

--- a/pkg/controller/deployment/version_test.go
+++ b/pkg/controller/deployment/version_test.go
@@ -85,7 +85,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				"deployments":  &appsv1.DeploymentList{},
 			},
 			apiErrors:     map[string]error{"get-deployments": errors.New("failed to get deployments")},
-			expectedError: "failed to check 'ceph --version' for provided image 'mirantis.azurecr.io/ceph/ceph:v20.2.2': failed to prepare version-check deployment: failed to get 'lcm-namespace/pelagia-check-ceph-version' deployment: failed to get deployments",
+			expectedError: "failed to check 'ceph --version' for provided image 'mirantis.azurecr.io/ceph/ceph:v20.2.3': failed to prepare version-check deployment: failed to get 'lcm-namespace/pelagia-check-ceph-version' deployment: failed to get deployments",
 		},
 		{
 			name:          "cephcluster not found, fresh deployment, incorrect ceph version inside image",
@@ -96,7 +96,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				"deployments":  &appsv1.DeploymentList{Items: []appsv1.Deployment{unitinputs.VersionCheckDeploymentReady(unitinputs.PelagiaConfig.Data["DEPLOYMENT_CEPH_IMAGE"])}},
 			},
 			cmdOutputs:    map[string]string{"ceph --version": "ceph version 3.3.3 (stable)"},
-			expectedError: "failed to check 'ceph --version' for provided image 'mirantis.azurecr.io/ceph/ceph:v20.2.2': unsupported Ceph major version 'v3.3' provided. Supported are: [Tentacle (v20.2) Squid (v19.2)]",
+			expectedError: "failed to check 'ceph --version' for provided image 'mirantis.azurecr.io/ceph/ceph:v20.2.3': unsupported Ceph major version 'v3.3' provided. Supported are: [Tentacle (v20.2) Squid (v19.2)]",
 		},
 		{
 			name:          "cephcluster not found, fresh deployment, version detected",
@@ -110,10 +110,10 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
 			expectedStatusVersion: "",
 		},
 		{
@@ -125,7 +125,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				"deployments":  &appsv1.DeploymentList{Items: []appsv1.Deployment{unitinputs.VersionCheckDeploymentReady(unitinputs.PelagiaConfig.Data["DEPLOYMENT_CEPH_IMAGE"])}},
 				"configmaps":   &corev1.ConfigMapList{},
 			},
-			expectedError: "failed to check 'ceph --version' for used in cluster image 'mirantis.azurecr.io/ceph/ceph:v20.2.2': failed to run command 'ceph --version': unexpected run ceph command: ceph --version",
+			expectedError: "failed to check 'ceph --version' for used in cluster image 'mirantis.azurecr.io/ceph/ceph:v20.2.3': failed to run command 'ceph --version': unexpected run ceph command: ceph --version",
 		},
 		{
 			name:          "cephcluster found, but not deployed yet, version detected",
@@ -140,10 +140,10 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
 			expectedStatusVersion: "",
 		},
 		{
@@ -232,7 +232,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				"ceph versions --format json": unitinputs.CephVersionsLatest,
 				"ceph --version":              unitinputs.CephVersionPrevious,
 			},
-			expectedError: "detected Ceph version downgrade from 'v20.2.2' to 'v19.2.4': major downgrade is not possible",
+			expectedError: "detected Ceph version downgrade from 'v20.2.3' to 'v19.2.4': major downgrade is not possible",
 		},
 		/* TODO: uncomment if more than 2 releases are supported at the time
 		{
@@ -257,7 +257,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				"cephclusters": &cephv1.CephClusterList{Items: []cephv1.CephCluster{
 					func() cephv1.CephCluster {
 						c := unitinputs.TestCephCluster.DeepCopy()
-						c.Spec.CephVersion.Image = "mirantis.azurecr.io/ceph/ceph:v20.2.2-0"
+						c.Spec.CephVersion.Image = "mirantis.azurecr.io/ceph/ceph:v20.2.3-0"
 						return *c
 					}(),
 				}},
@@ -271,11 +271,11 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
-			expectedStatusVersion: "v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
+			expectedStatusVersion: "v20.2.3",
 		},
 		{
 			name:          "ceph image different from desired image, failed to check upgrade allowed",
@@ -353,7 +353,7 @@ func TestVerifyCephVersions(t *testing.T) {
 				MinorVersion: "4",
 				Order:        19,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
 			expectedStatusVersion: "v19.2.4",
 		},
 		{
@@ -375,11 +375,11 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
 			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.0",
-			expectedStatusVersion: "v20.2.2",
+			expectedStatusVersion: "v20.2.3",
 		},
 		{
 			name:          "image versions aligned, remove check version deployment failed",
@@ -394,11 +394,11 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
-			expectedStatusVersion: "v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
+			expectedStatusVersion: "v20.2.3",
 			apiErrors:             map[string]error{"delete-deployments": errors.New("failed to delete deployment")},
 		},
 		{
@@ -414,11 +414,11 @@ func TestVerifyCephVersions(t *testing.T) {
 			expectedVersion: &lcmcommon.CephVersion{
 				Name:         "Tentacle",
 				MajorVersion: "v20.2",
-				MinorVersion: "2",
+				MinorVersion: "3",
 				Order:        20,
 			},
-			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.2",
-			expectedStatusVersion: "v20.2.2",
+			expectedImage:         "mirantis.azurecr.io/ceph/ceph:v20.2.3",
+			expectedStatusVersion: "v20.2.3",
 		},
 	}
 	oldRunCmd := lcmcommon.RunPodCommandWithValidation

--- a/test/unit/inputs/cephcluster.go
+++ b/test/unit/inputs/cephcluster.go
@@ -31,8 +31,8 @@ var CephClusterListNotReady = cephv1.CephClusterList{Items: []cephv1.CephCluster
 var CephClusterListHealthIssues = cephv1.CephClusterList{Items: []cephv1.CephCluster{CephClusterHasHealthIssues}}
 var CephClusterListExternal = cephv1.CephClusterList{Items: []cephv1.CephCluster{CephClusterExternal}}
 
-var cephClusterVersion = "20.2.2-0"
-var cephClusterImage = "some-registry.com/ceph:v20.2.2"
+var cephClusterVersion = "20.2.3-0"
+var cephClusterImage = "some-registry.com/ceph:v20.2.3"
 
 func BuildBaseCephCluster(name, namespace string) cephv1.CephCluster {
 	cephcluster := cephv1.CephCluster{


### PR DESCRIPTION
New version contains important fixes around ceph-volume and nvme.

(cherry picked from commit c39eed5ccfdef5cdd61849034f5b9a8bcc3ac9f0)

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>